### PR TITLE
SDK-3069 GetCleverTapID return value

### DIFF
--- a/Plugin/CleverTapUnity/CleverTapUnity-Scripts/CleverTapBinding.cs
+++ b/Plugin/CleverTapUnity/CleverTapUnity-Scripts/CleverTapBinding.cs
@@ -1098,6 +1098,7 @@ namespace CleverTap {
     }
 
     public static string GetCleverTapID() {
+        return "testCleverTapID";
     }
 
     public static void RecordScreenView(string screenName) {


### PR DESCRIPTION
Fix error `'CleverTapBinding.GetCleverTapID()': not all code paths return a value`. This happens when the Build platform is neither iOS nor Android.

Returns `testCleverTapID` to match the `ProfileGetCleverTapID()` implementation.