### PR TITLE
chore(SDK-3553) Additional methods for Variables and fix iOS

### DIFF
--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
@@ -754,14 +754,11 @@ public class CleverTapUnityPlugin implements SyncListener, InAppNotificationList
 
     public String getVariableValue(String variableName) {
         Object value = clevertap.getVariableValue(variableName);
-
-        // Convert the Object to its JSON string representation
-        if (value instanceof Map) {
-            return new JSONObject((Map<?, ?>) value).toString();
-        } else {
-            // For basic types, just return the string representation
-            return value != null ? value.toString() : null;
-        }
+		if (value == null) {
+			return null;
+		}
+		
+		return (value instanceof Map) ? new JSONObject((Map<?, ?>) value).toString() : value.toString();
     }
 
     public void syncVariables() {

--- a/CleverTap/Plugins/iOS/CleverTapBinding.m
+++ b/CleverTap/Plugins/iOS/CleverTapBinding.m
@@ -606,6 +606,11 @@ void CleverTap_syncVariables()
     [[CleverTapUnityManager sharedInstance] syncVariables];
 }
 
+void CleverTap_syncVariables(const BOOL isProduction)
+{
+    [[CleverTapUnityManager sharedInstance] syncVariables: isProduction];
+}
+
 void CleverTap_fetchVariables(int callbackId)
 {
     [[CleverTapUnityManager sharedInstance] fetchVariables:callbackId];

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.h
@@ -141,7 +141,8 @@
 
 #pragma mark - Variables
 - (void)syncVariables;
-- (void)fetchVariables:(int) callbackId;
+- (void)syncVariables:(BOOL)isProduction;
+- (void)fetchVariables:(int)callbackId;
 
 - (void)defineVar:(NSString *)name kind:(NSString *)kind andDefaultValue:(NSString *)defaultValue;
 - (NSString *)getVariableValue:(NSString *)name;

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -894,6 +894,10 @@ return jsonDict;
     [clevertap syncVariables];
 }
 
+- (void)syncVariables:(BOOL)isProduction {
+	[clevertap syncVariables:isProduction];
+}
+
 - (void)fetchVariables:(int) callbackId
 {
     [clevertap fetchVariables:^(BOOL success) {
@@ -956,9 +960,9 @@ return jsonDict;
     id value = [clevertap getVariableValue:name];
     
     // Check if value is not nil and is serializable to JSON
-    if (value && [NSJSONSerialization isValidJSONObject:value]) {
+    if (value) {
         NSError *error;
-        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:value options:0 error:&error];
+        NSData *jsonData = [NSJSONSerialization dataWithJSONObject:value options:NSUTF8StringEncoding error:&error];
 
         if (!jsonData) {
             NSLog(@"Error serializing JSON: %@", error);

--- a/CleverTap/Runtime/Android/AndroidPlatformVariable.cs
+++ b/CleverTap/Runtime/Android/AndroidPlatformVariable.cs
@@ -7,6 +7,9 @@ namespace CleverTapSDK.Android {
         internal override void SyncVariables() =>
             CleverTapAndroidJNI.CleverTapJNIInstance.Call("syncVariables");
 
+        internal override void SyncVariables(bool isProduction) =>
+            SyncVariables();
+
         internal override void FetchVariables(int callbackId) =>
             CleverTapAndroidJNI.CleverTapJNIInstance.Call("fetchVariables", callbackId);
 

--- a/CleverTap/Runtime/CleverTap.cs
+++ b/CleverTap/Runtime/CleverTap.cs
@@ -121,6 +121,11 @@ namespace CleverTapSDK {
             remove => cleverTapCallbackHandler.OnVariablesChanged -= value;
         }
 
+        public static event CleverTapCallbackDelegate OnOneTimeVariablesChanged {
+            add => cleverTapCallbackHandler.OnOneTimeVariablesChanged += value;
+            remove => cleverTapCallbackHandler.OnOneTimeVariablesChanged -= value;
+        }
+
         #endregion
 
         #region Methods - CleverTap Platform Bindings
@@ -425,6 +430,9 @@ namespace CleverTapSDK {
 
         public static void SyncVariables() => 
             cleverTapVariable.SyncVariables();
+
+        public static void SyncVariables(bool isProduction) =>
+            cleverTapVariable.SyncVariables(isProduction);
 
         public static void FetchVariables(Action<bool> isSucessCallback) => 
             cleverTapVariable.FetchVariables(isSucessCallback);

--- a/CleverTap/Runtime/Common/CleverTapCallbackHandler.cs
+++ b/CleverTap/Runtime/Common/CleverTapCallbackHandler.cs
@@ -45,6 +45,8 @@ namespace CleverTapSDK.Common {
 
         public event CleverTapCallbackDelegate OnVariablesChanged;
 
+        public event CleverTapCallbackDelegate OnOneTimeVariablesChanged;
+
         #endregion
 
         #region Default - Callback Methods
@@ -248,6 +250,11 @@ namespace CleverTapSDK.Common {
             CleverTapLogger.Log("Unity received variables changed");
             if (OnVariablesChanged != null) {
                 OnVariablesChanged();
+            }
+
+            if (OnOneTimeVariablesChanged != null) {
+                OnOneTimeVariablesChanged();
+                OnOneTimeVariablesChanged = null;
             }
         }
 

--- a/CleverTap/Runtime/Common/CleverTapPlatformVariable.cs
+++ b/CleverTap/Runtime/Common/CleverTapPlatformVariable.cs
@@ -111,6 +111,7 @@ namespace CleverTapSDK.Common {
         #endregion
 
         internal abstract void SyncVariables();
+        internal abstract void SyncVariables(bool isProduction);
         internal abstract void FetchVariables(int callbackId);
         protected abstract Var<T> DefineVariable<T>(string name, string kind, T defaultValue);
     }

--- a/CleverTap/Runtime/Common/Var.cs
+++ b/CleverTap/Runtime/Common/Var.cs
@@ -1,4 +1,7 @@
-﻿namespace CleverTapSDK.Common {
+﻿using CleverTapSDK.Constants;
+using CleverTapSDK.Utilities;
+
+namespace CleverTapSDK.Common {
     internal interface IVar {
         string Name { get; }
         string Kind { get; }
@@ -23,6 +26,7 @@
         public virtual string Name => name;
         public virtual T Value => value;
         public virtual T DefaultValue => defaultValue;
+        public virtual string StringValue => Kind == CleverTapVariableKind.DICTIONARY ? Json.Serialize(Value) : Value.ToString();
 
         public virtual void ValueChanged() {
             if (OnValueChanged != null) {

--- a/CleverTap/Runtime/IOS/IOSDllImport.cs
+++ b/CleverTap/Runtime/IOS/IOSDllImport.cs
@@ -248,6 +248,9 @@ namespace CleverTapSDK.IOS {
         internal static extern void CleverTap_syncVariables();
 
         [DllImport("__Internal")]
+        internal static extern void CleverTap_syncVariables(bool isProduction);
+
+        [DllImport("__Internal")]
         internal static extern void CleverTap_fetchVariables(int callbackId);
 
         #endregion

--- a/CleverTap/Runtime/IOS/IOSPlatformVariable.cs
+++ b/CleverTap/Runtime/IOS/IOSPlatformVariable.cs
@@ -7,6 +7,9 @@ namespace CleverTapSDK.IOS {
         internal override void SyncVariables() =>
             IOSDllImport.CleverTap_syncVariables();
 
+        internal override void SyncVariables(bool isProduction) =>
+            IOSDllImport.CleverTap_syncVariables(isProduction);
+
         internal override void FetchVariables(int callbackId) =>
             IOSDllImport.CleverTap_fetchVariables(callbackId);
 


### PR DESCRIPTION
- Added event OnOneTimeVariablesChanged
- Added StringValue  on Var
- Added SyncVariables(bool isProduction) for iOS (android will fallback to SyncVariables())
- Fix JSON validation issue in getVariableValue on iOS
- Simplified getVariableValue on Android