### PR TITLE
chore(SDK-3613) - Update AndroidPostImport

### DIFF
--- a/CleverTap/Editor/AndroidPostImport.cs
+++ b/CleverTap/Editor/AndroidPostImport.cs
@@ -9,6 +9,7 @@ namespace CleverTapSDK.Private
         {
             if (AssetDatabase.IsValidFolder("Assets/CleverTap/Plugins/Android/clevertap-android-wrapper") && importedAssets?.Length > 0 && importedAssets.Contains("Assets/CleverTap/Plugins/Android/clevertap-android-wrapper"))
             {
+                AssetDatabase.DeleteAsset("Assets/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib");
                 AssetDatabase.MoveAsset("Assets/CleverTap/Plugins/Android/clevertap-android-wrapper", "Assets/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib");
             }
         }


### PR DESCRIPTION
- On android-wrapper reimport, remove old version of .androidlib before converting new one