### PR TITLE
Fix create unitypackage

### DIFF
--- a/CleverTap/Editor/AndroidPostImport.cs
+++ b/CleverTap/Editor/AndroidPostImport.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using UnityEditor;
 
@@ -5,8 +6,14 @@ namespace CleverTapSDK.Private
 {
     class AndroidPostImport : AssetPostprocessor
     {
+        private static readonly string ctExportCommandLineArg = "-ct-export";
+
         static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths, bool didDomainReload)
         {
+            string[] cmdArgs = Environment.GetCommandLineArgs();
+            if (cmdArgs.Contains(ctExportCommandLineArg))
+                return;
+
             if (AssetDatabase.IsValidFolder("Assets/CleverTap/Plugins/Android/clevertap-android-wrapper") && importedAssets?.Length > 0 && importedAssets.Contains("Assets/CleverTap/Plugins/Android/clevertap-android-wrapper"))
             {
                 AssetDatabase.DeleteAsset("Assets/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib");

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib.meta
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib.meta
@@ -1,8 +1,81 @@
 fileFormatVersion: 2
-guid: b3a5de72654c24adc96ec93880610a3e
-folderAsset: yes
-DefaultImporter:
+guid: eaacb9252e249446c99a00b5f8bad6ae
+PluginImporter:
   externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Android: 0
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+        Exclude iOS: 1
+  - first:
+      Android: Android
+    second:
+      enabled: 1
+      settings:
+        AndroidSharedLibraryType: Executable
+        CPU: ARMv7
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Scripts/create_unity_package.sh
+++ b/Scripts/create_unity_package.sh
@@ -21,6 +21,7 @@ echo $ORIGINAL_ANDROID_LIB_FOLDER_PATH
 # Rename the folder
 if [ -d "$ORIGINAL_ANDROID_LIB_FOLDER_PATH" ]; then
     mv "$ORIGINAL_ANDROID_LIB_FOLDER_PATH" "$RENAMED_ANDROID_LIB_FOLDER_PATH"
+    mv "$ORIGINAL_ANDROID_LIB_FOLDER_PATH.meta" "$RENAMED_ANDROID_LIB_FOLDER_PATH.meta"
 else
     echo "Original folder not found!"
     exit 1
@@ -91,3 +92,4 @@ rm $SYMBOLIC_LINK_PATH
 
 # Revert the folder name back to original after the build
 mv "$RENAMED_ANDROID_LIB_FOLDER_PATH" "$ORIGINAL_ANDROID_LIB_FOLDER_PATH"
+mv "$RENAMED_ANDROID_LIB_FOLDER_PATH.meta" "$ORIGINAL_ANDROID_LIB_FOLDER_PATH.meta"

--- a/Scripts/create_unity_package.sh
+++ b/Scripts/create_unity_package.sh
@@ -78,6 +78,7 @@ fi
 echo "📦 Creating CleverTapSDK.unitypackage, this may take a minute."
 $UNITY_BIN -gvh_disable \
 -nographics \
+-ct-export \
 -projectPath $PROJECT \
 -force-free -quit -batchmode -logFile exportlog.txt \
 -importPackage $PROJECT/external-dependency-manager-latest.unitypackage \


### PR DESCRIPTION
## Background

1. The create unitypackage script fails to include the android-wrapper folder in the generated package.
2. The script fails to generate a correct package on consecutive runs.
3. The cleanup of renaming back the android-wrapper folder was causing it to be moved inside the original folder.
4. The android-wrapper folder was included inside iOS exports.

### android-wrapper androidLib Renaming
As explained by @PJClevertap, the android-wrapper folder has .androidLib in the name (`clevertap-android-wrapper.androidlib`) as recommended by Unity. This works fine with the UPM. When added as a local dependency, the android-wrapper is included and exported correctly.
The folder is not added when exporting the package by Unity, hence it is renamed without the `.androidLib` extension and packaged that way. The script then renames back the folder to `clevertap-android-wrapper.androidlib`.
When the unitypackage is imported, the android-wrapper folder is renamed to have `.androidLib` by the `AndroidPostImport` script.

## Implementation
1. The `AndroidPostImport` script is run when exporting the package. This renames again the android-wrapper folder and breaks the building of the package. Added a command line argument to identify when the export package is run, so AndroidPostImport script is not executed in this case.
2. The .meta file was not renamed. This with a combination of the symlinking, makes Unity generate an empty folder for the meta file. In the end, both `clevertap-android-wrapper.androidlib` and `clevertap-android-wrapper` folders exist, this causes the `mv` command to move the folder inside, instead of renaming it. This was breaking the consecutive runs.
3. See 2.
4. The `clevertap-android-wrapper.androidlib` folder is now marked as Android platform only.