### PR TITLE
Unity Native fixes

### DIFF
--- a/CleverTap/Runtime/Common/MonoHelper.cs
+++ b/CleverTap/Runtime/Common/MonoHelper.cs
@@ -3,48 +3,53 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-public class MonoHelper : MonoBehaviour
+namespace CleverTapSDK.Common
 {
-    private static MonoHelper _instance;
-    public static MonoHelper Instance
+    public class MonoHelper : MonoBehaviour
     {
-        get
+        private static MonoHelper _instance;
+        public static MonoHelper Instance
         {
-            if (_instance == null)
+            get
             {
-                var obj = new GameObject("MonoHelper");
-                _instance = obj.AddComponent<MonoHelper>();
-                DontDestroyOnLoad(obj);
+                if (_instance == null)
+                {
+                    var obj = new GameObject("MonoHelper");
+                    _instance = obj.AddComponent<MonoHelper>();
+                    DontDestroyOnLoad(obj);
+                }
+                return _instance;
             }
-            return _instance;
         }
-    }
 
-    private SynchronizationContext _context;
+        private SynchronizationContext _context;
 
-    private void Awake()
-    {
-        _instance = this;
-        _context = SynchronizationContext.Current;
-    }
+        private void Awake()
+        {
+            _instance = this;
+            _context = SynchronizationContext.Current;
+        }
 
-    public Task RunOnMainThread(Action action)
-    {
-        var tcs = new TaskCompletionSource<bool>();
-        _context.Post(_ => {
-            action();
-            tcs.SetResult(true);
-        }, null);
-        return tcs.Task;
-    }
+        public Task RunOnMainThread(Action action)
+        {
+            var tcs = new TaskCompletionSource<bool>();
+            _context.Post(_ =>
+            {
+                action();
+                tcs.SetResult(true);
+            }, null);
+            return tcs.Task;
+        }
 
-    public Task<T> RunOnMainThread<T>(Func<T> function)
-    {
-        var tcs = new TaskCompletionSource<T>();
-        _context.Post(_ => {
-            var result = function();
-            tcs.SetResult(result);
-        }, null);
-        return tcs.Task;
+        public Task<T> RunOnMainThread<T>(Func<T> function)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            _context.Post(_ =>
+            {
+                var result = function();
+                tcs.SetResult(result);
+            }, null);
+            return tcs.Task;
+        }
     }
 }

--- a/CleverTap/Runtime/Constants/CleverTapVersion.cs
+++ b/CleverTap/Runtime/Constants/CleverTapVersion.cs
@@ -1,5 +1,6 @@
 namespace CleverTapSDK.Constants {
     internal static class CleverTapVersion {
-        internal const string CLEVERTAP_SDK_VERSION = "3.1.0";
+        internal const string CLEVERTAP_SDK_VERSION = "4.0.0";
+        internal const string CLEVERTAP_SDK_REVISION = "40000";
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativePlatformBinding.cs
+++ b/CleverTap/Runtime/Native/UnityNativePlatformBinding.cs
@@ -11,9 +11,9 @@ namespace CleverTapSDK.Native {
         private readonly UnityNativeWrapper _unityNativeWrapper;
        
         internal UnityNativePlatformBinding() {
-            CallbackHandler = CreateGameObjectAndAttachCallbackHandler<UnityNativeCallbackHandler>(CleverTapGameObjectName.UNITY_NATIVE_CALLBACK_HANDLER);
-            _unityNativeWrapper = new UnityNativeWrapper();
-            CleverTapLogger.Log("Start: no-op CleverTap binding for non iOS/Android.");
+            UnityNativeCallbackHandler handler = CreateGameObjectAndAttachCallbackHandler<UnityNativeCallbackHandler>(CleverTapGameObjectName.UNITY_NATIVE_CALLBACK_HANDLER);
+            CallbackHandler = handler;
+            _unityNativeWrapper = new UnityNativeWrapper(handler);
         }
 
         internal override void LaunchWithCredentials(string accountID, string token) {
@@ -44,53 +44,45 @@ namespace CleverTapSDK.Native {
         internal override void RecordChargedEventWithDetailsAndItems(Dictionary<string, object> details, List<Dictionary<string, object>> items) {
             _unityNativeWrapper.RecordChargedEventWithDetailsAndItems(details, items);
         }
-
       
-        internal override void ProfileAddMultiValuesForKey(string key, List<string> values)
-        {
+        internal override void ProfileAddMultiValuesForKey(string key, List<string> values) {
             _unityNativeWrapper.ProfilePush(key, values, UnityNativeConstants.Commands.COMMAND_ADD);
         }
 
-        internal override void ProfileSetMultiValuesForKey(string key, List<string> values)
-        {
+        internal override void ProfileSetMultiValuesForKey(string key, List<string> values) {
             _unityNativeWrapper.ProfilePush(key, values, UnityNativeConstants.Commands.COMMAND_SET);
         }
 
-        internal override void ProfileRemoveMultiValuesForKey(string key, List<string> values)
-        {
+        internal override void ProfileRemoveMultiValuesForKey(string key, List<string> values) {
             _unityNativeWrapper.ProfilePush(key, values, UnityNativeConstants.Commands.COMMAND_REMOVE);
         }
 
-        internal override void ProfileIncrementValueForKey(string key, double val)
-        {
+        internal override void ProfileIncrementValueForKey(string key, double val) {
             _unityNativeWrapper.ProfilePush(key, val, UnityNativeConstants.Commands.COMMAND_INCREMENT);
         }
 
-        internal override void ProfileIncrementValueForKey(string key, int val)
-        {
+        internal override void ProfileIncrementValueForKey(string key, int val) {
             _unityNativeWrapper.ProfilePush(key, val, UnityNativeConstants.Commands.COMMAND_INCREMENT);
         }
 
-        internal override void ProfileDecrementValueForKey(string key, double val)
-        {
+        internal override void ProfileDecrementValueForKey(string key, double val) {
             _unityNativeWrapper.ProfilePush(key, val, UnityNativeConstants.Commands.COMMAND_DECREMENT);
         }
 
-        internal override void ProfileDecrementValueForKey(string key, int val)
-        {
+        internal override void ProfileDecrementValueForKey(string key, int val) {
             _unityNativeWrapper.ProfilePush(key, val, UnityNativeConstants.Commands.COMMAND_DECREMENT);
         }
 
-        internal override string GetCleverTapID()
-        {
+        internal override string GetCleverTapID() {
            return UnityNativeDeviceManager.Instance.DeviceInfo.DeviceId;
         }
 
-        private void generateDeviceId()
-        {
-            var guid = Guid.NewGuid().ToString();
-            string id = "-" + guid.Replace("-", "").Trim().ToLower();
-            PlayerPrefs.SetString(UnityNativeConstants.SDK.DEVICE_ID,id);
+        internal override string ProfileGetCleverTapID() {
+            return GetCleverTapID();
+        }
+
+        internal override void EnableDeviceNetworkInfoReporting(bool enabled) {
+            UnityNativeDeviceManager.Instance.DeviceInfo.EnableNetworkInfoReporting = enabled;
         }
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativePlatformBinding.cs
+++ b/CleverTap/Runtime/Native/UnityNativePlatformBinding.cs
@@ -33,6 +33,10 @@ namespace CleverTapSDK.Native {
             _unityNativeWrapper.ProfilePush(properties);
         }
 
+        internal override void ProfileRemoveValueForKey(string key) {
+            _unityNativeWrapper.ProfilePush(key, 1, UnityNativeConstants.Commands.COMMAND_DELETE);
+        }
+
         internal override void RecordEvent(string eventName) {
             _unityNativeWrapper.RecordEvent(eventName);
         }

--- a/CleverTap/Runtime/Native/UnityNativePlatformBinding.cs
+++ b/CleverTap/Runtime/Native/UnityNativePlatformBinding.cs
@@ -53,6 +53,10 @@ namespace CleverTapSDK.Native {
             _unityNativeWrapper.ProfilePush(key, values, UnityNativeConstants.Commands.COMMAND_ADD);
         }
 
+        internal override void ProfileAddMultiValueForKey(string key, string val) {
+            ProfileAddMultiValuesForKey(key, new List<string> { val });
+        }
+
         internal override void ProfileSetMultiValuesForKey(string key, List<string> values) {
             _unityNativeWrapper.ProfilePush(key, values, UnityNativeConstants.Commands.COMMAND_SET);
         }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
@@ -5,6 +5,15 @@ using System.Linq;
 
 namespace CleverTapSDK.Native {
     internal static class UnityNativeConstants {
+
+        internal static string GetStorageKeyWithAccountId(string suffix) {
+            string accountId = UnityNativeAccountManager.Instance.AccountInfo.AccountId;
+            if (string.IsNullOrEmpty(accountId))
+            {
+                throw new ArgumentNullException("Trying to get access storage key without account Id.");
+            }
+            return $"{accountId}:{suffix}";
+        }
       
         internal static class SDK {
             internal const string DEVICE_ID = "device_id";
@@ -178,7 +187,8 @@ namespace CleverTapSDK.Native {
         }
 
         internal static class Network {
-            internal const string CT_BASE_URL = "clevertap-prod.com"; //"sk1-staging-25.clevertap-prod.com";// "clevertap-prod.com";
+            internal const string CT_BASE_URL = "clevertap-prod.com";
+            internal const string REDIRECT_DOMAIN_KEY = "CLTAP_REDIRECT_DOMAIN_KEY";
             internal const string HEADER_ACCOUNT_ID_NAME = "X-CleverTap-Account-Id";
             internal const string HEADER_ACCOUNT_TOKEN_NAME = "X-CleverTap-Token";
             internal const string HEADER_DOMAIN_NAME = "X-WZRK-RD";
@@ -189,7 +199,6 @@ namespace CleverTapSDK.Native {
             internal const string QUERY_ACCOUNT_ID = "z";
             internal const string QUERY_CURRENT_TIMESTAMP = "ts";
 
-       
             internal const string REQUEST_GET = "GET";
 #if UNITY_WEBGL && !UNITY_EDITOR
             internal const string REQUEST_POST = "POST";

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
@@ -6,28 +6,35 @@ using System.Linq;
 namespace CleverTapSDK.Native {
     internal static class UnityNativeConstants {
       
-
         internal static class SDK {
             internal const string DEVICE_ID = "device_id";
 
             internal const string DEVICE_ID_TAG = "deviceId";
-            internal const string WEBGL_GUID_PREFIX =  "__u";
+            internal const string UNITY_GUID_PREFIX =  "__u";
             internal const string CACHED_GUIDS_KEY = "cachedGUIDsKey";
-
         }
+
+        internal static class OSNames {
+            internal const string WINDOWS = "Windows";
+            internal const string MACOS = "MacOS";
+            internal const string UNKNOWN = "Unknown";
+        }
+
         internal static class Profile {
             internal const string NAME = "name";
             internal const string EMAIL = "email";
             internal const string EDUCATION = "userEducation";
             internal const string MARRIED = "userMarried";
             internal const string DATE_OF_BIRTH = "DOB";
-            internal const string SOME_DATE = "SomeDate";
             internal const string BIRTHDAY = "userBirthday";
             internal const string EMPLOYED = "userEmployed";
             internal const string GENDER = "userGender";
-            internal const string PHONE = "userPhone";
+            internal const string USER_PHONE = "userPhone";
             internal const string AGE = "userAge";
             internal const string IDENTITY = "Identity";
+            internal const string PHONE = "Phone";
+            internal const string NETWORK_INFO = "NetworkInfo";
+
             internal static bool IsKeyKnownProfileField(string key) {
                 if (string.IsNullOrWhiteSpace(key)) {
                     return false;
@@ -63,22 +70,23 @@ namespace CleverTapSDK.Native {
                 if (keyLwc == GENDER.ToLower() || keyLwc == "gender") {
                     return GENDER;
                 }
-                if (keyLwc == PHONE.ToLower() || keyLwc == "phone") {
-                    return PHONE;
+                if (keyLwc == USER_PHONE.ToLower() || keyLwc == "phone") {
+                    return USER_PHONE;
                 }
                 if (keyLwc == AGE.ToLower() || keyLwc == "age") {
                     return AGE;
-                }
-                if (keyLwc == SOME_DATE.ToLower() || keyLwc == "someDate")
-                {
-                    return "SomeDate";
                 }
 
                 return null;
             }
         }
-        internal static class Event
-        {
+
+        internal static class Session {
+            internal const string SESSION_ID = "sessionId";
+            internal const string LAST_SESSION_TIME = "lastSessionTime";
+        }
+
+        internal static class Event {
             internal const string EVENT_NAME = "evtName";
             internal const string EVENT_DATA = "evtData";
 
@@ -97,8 +105,6 @@ namespace CleverTapSDK.Native {
 
             internal const string GEO_FENCE_LOCATION = "gf";
             internal const string GEO_FENCE_SDK_VERSION = "gfSDKVersion";
-
-            internal const string BUNDLE_IDENTIFIER = "pai";
 
             internal const string APP_VERSION = "Version";
             internal const string BUILD = "Build";
@@ -125,10 +131,9 @@ namespace CleverTapSDK.Native {
 
             internal const string LIBRARY = "lib";
 
-            internal const string RUNNING_INSIDE_APP_EXTENSION = "appex";
             internal const string LOCALE_IDENTIFIER = "locale";
-            internal const string WV_INIT = "wv_init";
         }
+
         internal static class EventMeta {
             internal const string TYPE = "type";
             internal const string TYPE_NAME = "meta";
@@ -148,6 +153,7 @@ namespace CleverTapSDK.Native {
             internal const string REF = "ref";
             internal const string WZRK_REF = "wzrk_ref";
         }
+
         internal static class Validator {
             internal const int MAX_KEY_CHARS = 120;
             internal const int MAX_VALUE_CHARS = 1024;
@@ -170,8 +176,9 @@ namespace CleverTapSDK.Native {
                 return RESTRICTED_NAMES.Select(rn => rn.ToLower()).Any(rn => rn == name.ToLower());
             }
         }
+
         internal static class Network {
-            internal const string CT_BASE_URL = "sk1-staging-25.clevertap-prod.com";// "clevertap-prod.com";
+            internal const string CT_BASE_URL = "clevertap-prod.com"; //"sk1-staging-25.clevertap-prod.com";// "clevertap-prod.com";
             internal const string HEADER_ACCOUNT_ID_NAME = "X-CleverTap-Account-Id";
             internal const string HEADER_ACCOUNT_TOKEN_NAME = "X-CleverTap-Token";
             internal const string HEADER_DOMAIN_NAME = "X-WZRK-RD";
@@ -195,8 +202,7 @@ namespace CleverTapSDK.Native {
             internal const string REQUEST_PATH_HAND_SHAKE = "hello";
         }
 
-        internal static class Commands
-        {
+        internal static class Commands {
             internal const string COMMAND_REMOVE = "$remove";
             internal const string COMMAND_ADD = "$add";
             internal const string COMMAND_SET = "$set";

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
@@ -194,6 +194,8 @@ namespace CleverTapSDK.Native {
             internal const string HEADER_DOMAIN_NAME = "X-WZRK-RD";
             internal const string HEADER_DOMAIN_MUTE = "X-WZRK-MUTE";
 
+            internal const int DEFAUL_REQUEST_TIMEOUT_SEC = 10;
+
             internal const string QUERY_OS = "os";
             internal const string QUERY_SKD_REVISION = "t";
             internal const string QUERY_ACCOUNT_ID = "z";

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
@@ -219,6 +219,7 @@ namespace CleverTapSDK.Native {
             internal const string COMMAND_SET = "$set";
             internal const string COMMAND_INCREMENT = "$incr";
             internal const string COMMAND_DECREMENT = "$decr";
+            internal const string COMMAND_DELETE = "$delete";
         }
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Constants/UnityNativeConstants.cs
@@ -8,8 +8,6 @@ namespace CleverTapSDK.Native {
       
 
         internal static class SDK {
-            internal const string REVISION = "30200";
-            internal const string VERSION = "3.2.0";
             internal const string DEVICE_ID = "device_id";
 
             internal const string DEVICE_ID_TAG = "deviceId";

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Enums/UnityNativeEventType.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Enums/UnityNativeEventType.cs
@@ -7,7 +7,7 @@ namespace CleverTapSDK.Native
         PageEvent = 1,
         PingEvent = 2,
         ProfileEvent = 3,
-        RecordEvent = 4,
+        RaisedEvent = 4,
         DataEvent = 5,
         NotificationViewEvent = 6,
         FetchEvent = 7

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeBaseEventBuilder.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeBaseEventBuilder.cs
@@ -49,7 +49,7 @@ namespace CleverTapSDK.Native {
 
             data.Add(UnityNativeConstants.Event.APP_VERSION, deviceInfo.AppVersion);
             data.Add(UnityNativeConstants.Event.BUILD, deviceInfo.AppBuild);
-            data.Add(UnityNativeConstants.Event.SDK_VERSION, Regex.Replace(deviceInfo.SdkVersion, "[^0-9]", "0"));
+            data.Add(UnityNativeConstants.Event.SDK_VERSION, deviceInfo.SdkVersion);
 
             if (!string.IsNullOrEmpty(deviceInfo.Model)) {
                 data.Add(UnityNativeConstants.Event.MODEL, deviceInfo.Model);

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeBaseEventBuilder.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeBaseEventBuilder.cs
@@ -20,7 +20,7 @@ namespace CleverTapSDK.Native {
                 case UnityNativeEventType.ProfileEvent:
                     eventData.Add(UnityNativeConstants.Event.EVENT_TYPE, UnityNativeConstants.Event.EVENT_TYPE_PROFILE);
                     break;
-                case UnityNativeEventType.RecordEvent:
+                case UnityNativeEventType.RaisedEvent:
                     eventData.Add(UnityNativeConstants.Event.EVENT_TYPE, UnityNativeConstants.Event.EVENT_TYPE_EVENT); 
                     break;
                 default:

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeBaseEventBuilder.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeBaseEventBuilder.cs
@@ -1,7 +1,7 @@
 #if !UNITY_IOS && !UNITY_ANDROID
 using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
+using CleverTapSDK.Utilities;
 
 namespace CleverTapSDK.Native {
     internal class UnityNativeEventBuilder {
@@ -11,6 +11,7 @@ namespace CleverTapSDK.Native {
         internal Dictionary<string, object> BuildEvent(UnityNativeEventType eventType, Dictionary<string, object> eventDetails) {
            
             if (UnityNativeNetworkEngine.Instance.IsMuted()) {
+                CleverTapLogger.Log("Not building event. CleverTap is Muted.");
                 return null;
             }
                 
@@ -20,10 +21,7 @@ namespace CleverTapSDK.Native {
                     eventData.Add(UnityNativeConstants.Event.EVENT_TYPE, UnityNativeConstants.Event.EVENT_TYPE_PROFILE);
                     break;
                 case UnityNativeEventType.RecordEvent:
-                    eventData.Add(UnityNativeConstants.Event.EVENT_TYPE, UnityNativeConstants.Event.EVENT_TYPE_EVENT);
-                    if (!string.IsNullOrEmpty(UnityNativeDeviceManager.Instance.DeviceInfo.BundleId)) {
-                        eventData.Add(UnityNativeConstants.Event.BUNDLE_IDENTIFIER, UnityNativeDeviceManager.Instance.DeviceInfo.BundleId);
-                    }   
+                    eventData.Add(UnityNativeConstants.Event.EVENT_TYPE, UnityNativeConstants.Event.EVENT_TYPE_EVENT); 
                     break;
                 default:
                     // NOT Supported YET
@@ -37,19 +35,28 @@ namespace CleverTapSDK.Native {
             eventData.Add(UnityNativeConstants.Event.SCREEN_COUNT, UnityNativeSessionManager.Instance.GetScreenCount());
             eventData.Add(UnityNativeConstants.Event.LAST_SESSION_LENGTH_SECONDS, UnityNativeSessionManager.Instance.GetLastSessionLength());
             eventData.Add(UnityNativeConstants.Event.IS_FIRST_SESSION, UnityNativeSessionManager.Instance.IsFirstSession());
-            // Check if this is needed
-            eventData.Add("n", "_bg");
+
+            string screenName = UnityNativeSessionManager.Instance.GetScreenName();
+            if (!string.IsNullOrEmpty(screenName)) {
+                eventData.Add("n", screenName);
+            }
 
             return eventData;
         }
+
         internal Dictionary<string, object> BuildAppFields() {
             var deviceInfo = UnityNativeDeviceManager.Instance.DeviceInfo;
 
-            var data = new Dictionary<string, object>();
-
-            data.Add(UnityNativeConstants.Event.APP_VERSION, deviceInfo.AppVersion);
-            data.Add(UnityNativeConstants.Event.BUILD, deviceInfo.AppBuild);
-            data.Add(UnityNativeConstants.Event.SDK_VERSION, deviceInfo.SdkVersion);
+            var data = new Dictionary<string, object>
+            {
+                { UnityNativeConstants.Event.APP_VERSION, deviceInfo.AppVersion },
+                { UnityNativeConstants.Event.BUILD, deviceInfo.AppBuild },
+                { UnityNativeConstants.Event.SDK_VERSION, deviceInfo.SdkVersion },
+                { UnityNativeConstants.Event.OS_VERSION, deviceInfo.OsVersion },
+                { UnityNativeConstants.Event.OS_NAME, deviceInfo.OsName },
+                { UnityNativeConstants.Event.SCREEN_WIDTH, deviceInfo.DeviceWidth },
+                { UnityNativeConstants.Event.SCREEN_HEIGHT, deviceInfo.DeviceHeight }
+            };
 
             if (!string.IsNullOrEmpty(deviceInfo.Model)) {
                 data.Add(UnityNativeConstants.Event.MODEL, deviceInfo.Model);
@@ -59,32 +66,24 @@ namespace CleverTapSDK.Native {
                 data.Add(UnityNativeConstants.Event.MANUFACTURER, deviceInfo.Manufacturer);
             }
 
-            data.Add(UnityNativeConstants.Event.OS_VERSION, deviceInfo.OsVersion);
-
             if (!string.IsNullOrEmpty(deviceInfo.Carrier)) {
                 data.Add(UnityNativeConstants.Event.CARRIER, deviceInfo.Carrier);
             }
 
-            // Check this
-            var useIp = false;
+            var useIp = deviceInfo.EnableNetworkInfoReporting;
             data.Add(UnityNativeConstants.Event.USE_IP, useIp);
-            if (useIp) {
-                // Check network Type
-                //data.Add(UnityNativeConstants.Event.NETWORK_TYPE, "")
-
-                data.Add(UnityNativeConstants.Event.CONNECTED_TO_WIFI, deviceInfo.Wifi);
+            if (useIp)
+            {
+                if (!string.IsNullOrEmpty(deviceInfo.Radio))
+                {
+                    data.Add(UnityNativeConstants.Event.NETWORK_TYPE, deviceInfo.Radio);
+                }
+                if (deviceInfo.Wifi != -1)
+                {
+                    data.Add(UnityNativeConstants.Event.CONNECTED_TO_WIFI, deviceInfo.Wifi);
+                }
             }
-
-            // Check this
-            var runningInsideAppExtension = false;
-            if (runningInsideAppExtension) {
-                data.Add(UnityNativeConstants.Event.RUNNING_INSIDE_APP_EXTENSION, 1);
-            }
-
-            data.Add(UnityNativeConstants.Event.OS_NAME, deviceInfo.OsName);
-            data.Add(UnityNativeConstants.Event.SCREEN_WIDTH, deviceInfo.DeviceWidth);
-            data.Add(UnityNativeConstants.Event.SCREEN_HEIGHT, deviceInfo.DeviceHeight);
-
+            
             if (!string.IsNullOrEmpty(deviceInfo.CountryCode)) {
                 data.Add(UnityNativeConstants.Event.COUNTRY_CODE, deviceInfo.CountryCode);
             }
@@ -93,29 +92,9 @@ namespace CleverTapSDK.Native {
                 data.Add(UnityNativeConstants.Event.LOCALE_IDENTIFIER, deviceInfo.Locale);
             }
 
-            // sslpin
-            //data.Add(UnityNativeConstants.Event.SSL_PINNING, false);
-
-            // Check this
-            //string proxyDomain = null;
-            //if (!string.IsNullOrEmpty(proxyDomain)) {
-            //    data.Add(UnityNativeConstants.Event.PROXY_DOMAIN, proxyDomain);
-            //}
-
-            // Check this
-            //string spikyProxyDomain = null;
-            //if (!string.IsNullOrEmpty(spikyProxyDomain)) {
-            //    data.Add(UnityNativeConstants.Event.SPIKY_PROXY_DOMAIN, spikyProxyDomain);
-            //}
-
-            // Check this
-            bool wv_init = false;
-            if (wv_init) {
-                data.Add(UnityNativeConstants.Event.WV_INIT, true);
-            }
-
             return data;
         }
+
         internal Dictionary<string, object> BuildEventWithAppFields(UnityNativeEventType eventType, Dictionary<string, object> eventDetails) {
             var eventData = BuildEvent(eventType, eventDetails);
             eventData.Add(UnityNativeConstants.Event.EVENT_DATA, BuildAppFields());

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeMetaEventBuilder.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeMetaEventBuilder.cs
@@ -10,24 +10,15 @@ namespace CleverTapSDK.Native {
             var deviceInfo = UnityNativeDeviceManager.Instance.DeviceInfo;
             var accountInfo = UnityNativeAccountManager.Instance.AccountInfo;
 
-            var metaDetails = new Dictionary<string, object>();
-            metaDetails.Add(UnityNativeConstants.EventMeta.GUID, deviceInfo.DeviceId);
-            metaDetails.Add(UnityNativeConstants.EventMeta.TYPE, UnityNativeConstants.EventMeta.TYPE_NAME);
-            metaDetails.Add(UnityNativeConstants.EventMeta.APPLICATION_FIELDS, new UnityNativeEventBuilder().BuildAppFields());
-            metaDetails.Add(UnityNativeConstants.EventMeta.ACCOUNT_ID, accountInfo.AccountId);
-            metaDetails.Add(UnityNativeConstants.EventMeta.ACCOUNT_TOKEN, accountInfo.AccountToken);
-            //TODO: metaDetails.Add(UnityNativeConstants.EventMeta.STORED_DEVICE_TOKEN, null); Add this implementation if needed
-            metaDetails.Add(UnityNativeConstants.EventMeta.FIRST_REQUEST_IN_SESSION, UnityNativeSessionManager.Instance.IsFirstSession());
-            metaDetails.Add(UnityNativeConstants.EventMeta.FIRST_REQUEST_TIMESTAMP, DateTimeOffset.UtcNow.ToUnixTimeSeconds()); // Add this implementation
-            metaDetails.Add(UnityNativeConstants.EventMeta.LAST_REQUEST_TIMESTAMP, DateTimeOffset.UtcNow.ToUnixTimeSeconds()); // Add this implementation
-           // TODO: 
-            //metaDetails.Add(UnityNativeConstants.EventMeta.DEBUG_LEVEL, 3); // Add this implementation if needed
-            //metaDetails.Add(UnityNativeConstants.EventMeta.SOURCE, null); // Add this implementation if needed
-            //metaDetails.Add(UnityNativeConstants.EventMeta.MEDIUM, null); // Add this implementation if needed
-            //metaDetails.Add(UnityNativeConstants.EventMeta.CAMPAIGN, null); // Add this implementation if needed
-            //metaDetails.Add(UnityNativeConstants.EventMeta.SOURCE, null); // Add this implementation if needed
-            //metaDetails.Add(UnityNativeConstants.EventMeta.REF, null); // Add this implementation if needed
-            //metaDetails.Add(UnityNativeConstants.EventMeta.WZRK_REF, null); // Add this implementation if needed
+            var metaDetails = new Dictionary<string, object>
+            {
+                { UnityNativeConstants.EventMeta.GUID, deviceInfo.DeviceId },
+                { UnityNativeConstants.EventMeta.TYPE, UnityNativeConstants.EventMeta.TYPE_NAME },
+                { UnityNativeConstants.EventMeta.APPLICATION_FIELDS, new UnityNativeEventBuilder().BuildAppFields() },
+                { UnityNativeConstants.EventMeta.ACCOUNT_ID, accountInfo.AccountId },
+                { UnityNativeConstants.EventMeta.ACCOUNT_TOKEN, accountInfo.AccountToken },
+                { UnityNativeConstants.EventMeta.FIRST_REQUEST_IN_SESSION, UnityNativeSessionManager.Instance.IsFirstSession() }
+            };
 
             return metaDetails;
         }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeRaisedEventBuilder.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeRaisedEventBuilder.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using CleverTapSDK.Utilities;
 
 namespace CleverTapSDK.Native {
-    internal class UnityNativeRecordEventBuilder {
-        internal UnityNativeRecordEventBuilder() { }
+    internal class UnityNativeRaisedEventBuilder {
+        internal UnityNativeRaisedEventBuilder() { }
 
         internal UnityNativeEventBuilderResult<Dictionary<string, object>> Build(string eventName, Dictionary<string, object> properties = null) {
             var eventValidator = new UnityNativeEventValidator();

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeRaisedEventBuilder.cs.meta
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeRaisedEventBuilder.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b4b799805760c472e8bfc36ce7c103f9
+guid: ada95b91187164ba983a870721e9e3dd
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeRecordEventBuilder.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/EventBuilders/UnityNativeRecordEventBuilder.cs
@@ -1,6 +1,7 @@
 #if !UNITY_IOS && !UNITY_ANDROID
 using System.Collections.Generic;
 using System.Linq;
+using CleverTapSDK.Utilities;
 
 namespace CleverTapSDK.Native {
     internal class UnityNativeRecordEventBuilder {
@@ -50,7 +51,9 @@ namespace CleverTapSDK.Native {
             }
 
             if (items.Count > 50) {
-                // TODO: Log error?
+                CleverTapLogger.Log("Charged event contained more than 50 items.");
+                eventValidationResultsWithErrors.Add(new UnityNativeValidationResult(522, "Charged event contained more than 50 items."));
+                return new UnityNativeEventBuilderResult<Dictionary<string, object>>(eventValidationResultsWithErrors, null);
             }
 
             var eventDetails = new Dictionary<string, object>();

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeBaseEventQueue.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeBaseEventQueue.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CleverTapSDK.Utilities;
 using UnityEngine;
+using CleverTapSDK.Common;
 
 namespace CleverTapSDK.Native
 {

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeBaseEventQueue.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeBaseEventQueue.cs
@@ -54,7 +54,6 @@ namespace CleverTapSDK.Native
 
         protected virtual void OnTimerTick()
         {
-            CleverTapLogger.Log("Timer TICK");
             OnEventTimerTick?.Invoke();
             StopTimer();
         }
@@ -83,9 +82,6 @@ namespace CleverTapSDK.Native
                     var request = new UnityNativeRequest(RequestPath, UnityNativeConstants.Network.REQUEST_POST)
                         .SetRequestBody(jsonContent)
                         .SetQueryParameters(queryStringParameters);
-
-                    CleverTapLogger.Log($"{GetType().Name}: Sending request with body: {jsonContent} " +
-                        $"and query parameters: [{string.Join(", ", queryStringParameters.Select(kv => $"{kv.Key}: {kv.Value}"))}]");
 
                     var response = await executeRequest(request);
 
@@ -155,7 +151,6 @@ namespace CleverTapSDK.Native
 
         protected virtual void ResetAndStartTimer(bool retry = false)
         {
-            CleverTapLogger.Log("ResetAndStartTimer");
             if (retryCount == 0)
             {
                 RestartTimer(defaultTimerInterval);
@@ -172,7 +167,6 @@ namespace CleverTapSDK.Native
         {
             StopTimer();
             timerCoroutine = MonoHelper.Instance.StartCoroutine(TimerCoroutine(duration));
-            CleverTapLogger.Log("Timer Restarted");
         }
 
         private IEnumerator TimerCoroutine(float duration)

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeDeviceInfo.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeDeviceInfo.cs
@@ -1,13 +1,14 @@
 #if !UNITY_IOS && !UNITY_ANDROID
 using System;
 using UnityEngine;
+using CleverTapSDK.Constants;
 
 namespace CleverTapSDK.Native {
+
     internal class UnityNativeDeviceInfo {
         private readonly string _sdkVersion;
         private readonly string _appVersion;
         private readonly string _appBuild;
-        private readonly string _bundleId;
         private readonly string _osName;
         private readonly string _osVersion;
         private readonly string _manufacturer;
@@ -19,32 +20,28 @@ namespace CleverTapSDK.Native {
         private readonly string _vendorIdentifier;
         private readonly string _deviceWidth;
         private readonly string _deviceHeight;
-        private readonly string _deviceId;
         private readonly string _library;
-        private readonly bool _wifi;
+        private readonly int _wifi;
         private readonly string _locale;
 
-//TODO: test and log info for MAC, windows and WEBGl
         internal UnityNativeDeviceInfo() {
-            // Use the SDK Version Revision
-            _sdkVersion = CleverTapVersion.CLEVERTAP_SDK_REVISION;
-            _appVersion = Application.version; // Check where to get this
-            _appBuild = Application.productName; // Check where to get this
-            _bundleId = "123456789"; // Check if we need this and how to get
+            _sdkVersion = CleverTapVersion.CLEVERTAP_SDK_REVISION; // Use the SDK Version Revision
+            _appVersion = Application.version;
+            _appBuild = Application.productName;
             _osName = GetOSName(); // Only suppport for Windows and MacOS
             _osVersion = SystemInfo.operatingSystem;
-            _manufacturer = SystemInfo.deviceModel; // Check if we need this and is it correct
-            _model = SystemInfo.deviceModel; // Check if we need this
-            _carrier = null; // Check if we need this and how to get
-            _countryCode = null; // Check if we need this and how to get
-            _timeZone = null; // Check if we need this and how to get
-            _radio = null; // Check if we need this and how to get
-            _vendorIdentifier = null; // Check if we need this and how to get
-            _deviceWidth = Screen.width.ToString(); // Check if we need this and is it correct
-            _deviceHeight = Screen.height.ToString(); // Check if we need this and is it correct
-            _library = null; // Check if we need this and how to get
-            _wifi = false; // Check if we need this and how to get
-            _locale = "xx_XX"; // Check if we need this and how to get
+            _manufacturer = SystemInfo.deviceModel;
+            _model = SystemInfo.deviceModel;
+            _carrier = null;
+            _countryCode = null;
+            _timeZone = null;
+            _radio = null;
+            _vendorIdentifier = null;
+            _deviceWidth = Screen.width.ToString();
+            _deviceHeight = Screen.height.ToString();
+            _library = null;
+            _wifi = -1;
+            _locale = null;
         }
 
         internal string SdkVersion => _sdkVersion;
@@ -52,8 +49,6 @@ namespace CleverTapSDK.Native {
         internal string AppVersion => _appVersion;
 
         internal string AppBuild => _appBuild;
-
-        internal string BundleId => _bundleId;
 
         internal string OsName => _osName;
 
@@ -77,73 +72,67 @@ namespace CleverTapSDK.Native {
 
         internal string DeviceHeight => _deviceHeight;
 
+        internal string DeviceId => GetDeviceId();
+
         internal string Library => _library;
 
-        internal bool Wifi => _wifi;
+        internal int Wifi => _wifi;
 
         internal string Locale => _locale;
 
-        internal string DeviceId {
-            get {
-                return GetDeviceId();
+        internal bool EnableNetworkInfoReporting {
+            get
+            {
+                return PlayerPrefs.GetInt(GetStorageKey(UnityNativeConstants.Profile.NETWORK_INFO), 0) == 1;
+            }
+            set
+            {
+                PlayerPrefs.SetInt(GetStorageKey(UnityNativeConstants.Profile.NETWORK_INFO), value ? 1 : 0);
             }
         }
 
         private string GetOSName() {
             var operatingSystem = SystemInfo.operatingSystem?.ToLower().Replace(" ", "");
 
-            if (operatingSystem?.ToLower().Contains("windows") == true) {
-                return "Windows";
+            if (operatingSystem?.ToLower().Contains(UnityNativeConstants.OSNames.WINDOWS.ToLower()) == true) {
+                return UnityNativeConstants.OSNames.WINDOWS;
             }
 
-            if (operatingSystem?.ToLower().Contains("macos") == true) {
-                return "MacOS";
+            if (operatingSystem?.ToLower().Contains(UnityNativeConstants.OSNames.MACOS.ToLower()) == true) {
+                return UnityNativeConstants.OSNames.MACOS;
             }
 
-            return "Unknown";
+            return UnityNativeConstants.OSNames.UNKNOWN;
         }
 
-        private string GetDeviceId()
-        {
+        private string GetDeviceId() {
             if (!PlayerPrefs.HasKey(GetDeviceIdStorageKey()))
+            {
                 ForceNewDeviceID();
+            }
             return PlayerPrefs.GetString(GetDeviceIdStorageKey(), null);
         }
 
-        public void ForceNewDeviceID()
-        {
+        public void ForceNewDeviceID() {
             string newDeviceID = GenerateGuid();
             ForceUpdateDeviceId(newDeviceID);
         }
 
-        public void ForceUpdateDeviceId(string id)
-        {
+        public void ForceUpdateDeviceId(string id) {
             PlayerPrefs.SetString(GetDeviceIdStorageKey(), id);
         }
 
-        private string GenerateGuid()
-        {
-            return UnityNativeConstants.SDK.WEBGL_GUID_PREFIX + Guid.NewGuid().ToString().Replace("-", "");
+        private string GenerateGuid() {
+            string id = Guid.NewGuid().ToString().Replace("-", "");
+            return $"{UnityNativeConstants.SDK.UNITY_GUID_PREFIX}{id}";
         }
 
-        private string GetDeviceIdStorageKey()
-        {
-            return UnityNativeConstants.SDK.DEVICE_ID_TAG + ":" + UnityNativeAccountManager.Instance.AccountInfo.AccountId;
+        private string GetDeviceIdStorageKey() {
+            return GetStorageKey(UnityNativeConstants.SDK.DEVICE_ID_TAG);
         }
 
-        private bool ValidateCleverTapID(string cleverTapID)
-        {
-            // Add your validation logic here
-            return !string.IsNullOrEmpty(cleverTapID);
-        }
-
-        private void InitializeDeviceId()
-        {
-            string storedDeviceId = GetDeviceId();
-            if (string.IsNullOrEmpty(storedDeviceId))
-            {
-                ForceNewDeviceID();
-            }
+        internal string GetStorageKey(string suffix) {
+            return $"{UnityNativeAccountManager.Instance.AccountInfo.AccountId}:{suffix}";
         }
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeDeviceInfo.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeDeviceInfo.cs
@@ -26,7 +26,8 @@ namespace CleverTapSDK.Native {
 
 //TODO: test and log info for MAC, windows and WEBGl
         internal UnityNativeDeviceInfo() {
-            _sdkVersion = UnityNativeConstants.SDK.VERSION;
+            // Use the SDK Version Revision
+            _sdkVersion = CleverTapVersion.CLEVERTAP_SDK_REVISION;
             _appVersion = Application.version; // Check where to get this
             _appBuild = Application.productName; // Check where to get this
             _bundleId = "123456789"; // Check if we need this and how to get

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeDeviceInfo.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeDeviceInfo.cs
@@ -132,7 +132,7 @@ namespace CleverTapSDK.Native {
         }
 
         internal string GetStorageKey(string suffix) {
-            return $"{UnityNativeAccountManager.Instance.AccountInfo.AccountId}:{suffix}";
+            return UnityNativeConstants.GetStorageKeyWithAccountId(suffix);
         }
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRaisedEventQueue.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRaisedEventQueue.cs
@@ -4,11 +4,11 @@ using System.Threading.Tasks;
 
 namespace CleverTapSDK.Native {
 
-    internal class UnityNativeRecordEventQueue : UnityNativeBaseEventQueue {
+    internal class UnityNativeRaisedEventQueue : UnityNativeBaseEventQueue {
 
-        protected override string QueueName => "RECORD_EVENTS";
+        protected override string QueueName => "RAISED_EVENTS";
 
-        internal UnityNativeRecordEventQueue(int queueLimit = 49, int defaultTimerInterval = 1) : base(queueLimit, defaultTimerInterval) { }
+        internal UnityNativeRaisedEventQueue(int queueLimit = 49, int defaultTimerInterval = 1) : base(queueLimit, defaultTimerInterval) { }
 
         protected override string RequestPath => UnityNativeConstants.Network.REQUEST_PATH_RECORD;
 

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRaisedEventQueue.cs.meta
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRaisedEventQueue.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 57f981276f2424654b16501224056bea
+guid: f445c8b9b62324c3e89b1853115a84e6
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRecordEventQueue.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRecordEventQueue.cs
@@ -6,6 +6,7 @@ namespace CleverTapSDK.Native {
 
     internal class UnityNativeRecordEventQueue : UnityNativeBaseEventQueue {
 
+        protected override string QueueName => "RECORD_EVENTS";
 
         internal UnityNativeRecordEventQueue(int queueLimit = 49, int defaultTimerInterval = 1) : base(queueLimit, defaultTimerInterval) { }
 
@@ -18,8 +19,7 @@ namespace CleverTapSDK.Native {
 
         protected override bool CanProcessEventResponse(UnityNativeResponse response)
         {
-            bool processHeaders = UnityNativeNetworkEngine.Instance.ProcessIncomingHeaders(response);
-            return processHeaders && response.IsSuccess();
+            return response.IsSuccess();
         }
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRequest.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRequest.cs
@@ -19,12 +19,13 @@ namespace CleverTapSDK.Native {
         private KeyValuePair<string, string>? _authorization;
         private IReadOnlyList<IUnityNativeRequestInterceptor> _requestInterceptors;
         private IReadOnlyList<IUnityNativeResponseInterceptor> _responseInterceptors;
-        private IReadOnlyDictionary<string, string> _addtionalProperties;
+        private IReadOnlyDictionary<string, string> _additionalProperties;
+        private bool _shouldRetry;
 
-        internal UnityNativeRequest(string path, string method, Dictionary<string, string> addtionalProperties = null) {
+        internal UnityNativeRequest(string path, string method, Dictionary<string, string> additionalProperties = null) {
             _path = path;
             _method = method?.ToUpper();
-            _addtionalProperties = addtionalProperties;
+            _additionalProperties = additionalProperties;
         }
 
         internal int? Timeout => _timeout;
@@ -34,7 +35,7 @@ namespace CleverTapSDK.Native {
         internal KeyValuePair<string, string>? Authorization => _authorization;
         internal IReadOnlyList<IUnityNativeRequestInterceptor> RequestInterceptors => _requestInterceptors;
         internal IReadOnlyList<IUnityNativeResponseInterceptor> ResponseInterceptors => _responseInterceptors;
-        internal IReadOnlyDictionary<string, string> AddtionalProperties => _addtionalProperties;
+        internal IReadOnlyDictionary<string, string> AdditionalProperties => _additionalProperties;
 
         internal UnityNativeRequest SetTimeout(int? timeout) {
             _timeout = timeout;
@@ -97,9 +98,13 @@ namespace CleverTapSDK.Native {
             if (_timeout != null) {
                 request.timeout = _timeout.Value;
             }
+            else
+            {
+                request.timeout = UnityNativeConstants.Network.DEFAUL_REQUEST_TIMEOUT_SEC;
+            }
 
             CleverTapLogger.Log($"Build Request: {uri}, with body: {_requestBody}, " +
-                $"and query parameters: [{string.Join(", ", _queryParameters.Select(kv => $"{kv.Key}: {kv.Value}"))}]");
+                $"and query parameters: [{Json.Serialize(_queryParameters)}]");
 
             return request;
         }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRequest.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRequest.cs
@@ -1,8 +1,10 @@
 ﻿#if !UNITY_IOS && !UNITY_ANDROID
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using CleverTapSDK.Utilities;
+using UnityEngine;
 using UnityEngine.Networking;
 
 namespace CleverTapSDK.Native {
@@ -77,7 +79,6 @@ namespace CleverTapSDK.Native {
             }
             else if (_method == UnityNativeConstants.Network.REQUEST_POST) {
                 request = UnityWebRequest.Post(uri, _requestBody, "application/json");
-                
             }
             else {
                 throw new NotSupportedException("Http method is not supported");
@@ -96,6 +97,9 @@ namespace CleverTapSDK.Native {
             if (_timeout != null) {
                 request.timeout = _timeout.Value;
             }
+
+            CleverTapLogger.Log($"Build Request: {uri}, with body: {_requestBody}, " +
+                $"and query parameters: [{string.Join(", ", _queryParameters.Select(kv => $"{kv.Key}: {kv.Value}"))}]");
 
             return request;
         }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeSession.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeSession.cs
@@ -1,47 +1,61 @@
 ﻿#if !UNITY_IOS && !UNITY_ANDROID
 using System;
+using UnityEngine;
 
 namespace CleverTapSDK.Native {
     internal class UnityNativeSession {
         private readonly long _sessionId;
-        private readonly long _startTimestamp;
         private readonly bool _isFirstSession;
-        
+        private readonly long _lastSessionLength;
+
         private bool _isAppLaunched;
         private long _lastUpdateTimestamp;
-        private string _userIdentity;
 
-        internal UnityNativeSession(bool isFirstSession = false, string userIdentity = null)
+        internal UnityNativeSession()
         {
-            _sessionId =  DateTime.Now.Millisecond / 1000;
-            _startTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-            _isFirstSession = isFirstSession;
+            long now = GetNow();
+            _sessionId = now;
+            _lastUpdateTimestamp = now;
             _isAppLaunched = false;
-            _lastUpdateTimestamp = _startTimestamp;
-            _userIdentity = userIdentity;
+
+            long lastSessionId = long.Parse(PlayerPrefs.GetString(GetStorageKey(UnityNativeConstants.Session.SESSION_ID), "0"));
+            if (lastSessionId == 0)
+            {
+                _isFirstSession = true;
+            }
+
+            long lastSessionTime = long.Parse(PlayerPrefs.GetString(GetStorageKey(UnityNativeConstants.Session.LAST_SESSION_TIME), "0"));
+            if (lastSessionTime > 0)
+            {
+                _lastSessionLength = lastSessionTime - lastSessionId;
+            }
+
+            PlayerPrefs.SetString(GetStorageKey(UnityNativeConstants.Session.SESSION_ID), _sessionId.ToString());
         }
         
         internal long SessionId => _sessionId;
-        internal long StartTimestamp => _startTimestamp;
+        internal long LastSessionLength => _lastSessionLength;
         internal bool IsFirstSession => _isFirstSession;
-        internal bool isAppLaunched => _isAppLaunched;
+        internal bool IsAppLaunched => _isAppLaunched;
         internal long LastUpdateTimestamp => _lastUpdateTimestamp;
-        internal string UserIdentity => _userIdentity;
 
         internal void SetIsAppLaunched(bool isAppLaunched) {
             _isAppLaunched = isAppLaunched;
         }
 
         internal long UpdateTimestamp() {
-            _lastUpdateTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+            long now = GetNow();
+            PlayerPrefs.SetString(GetStorageKey(UnityNativeConstants.Session.LAST_SESSION_TIME), now.ToString());
+            _lastUpdateTimestamp = now;
             return _lastUpdateTimestamp;
         }
 
-        internal void SetUserIdentity(string userIdentity) {
-            if (_userIdentity == null) {
-                _userIdentity = userIdentity;
-                UpdateTimestamp();
-            }
+        internal string GetStorageKey(string suffix) {
+            return $"{UnityNativeAccountManager.Instance.AccountInfo.AccountId}:{suffix}";
+        }
+
+        internal long GetNow() {
+            return DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         }
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeSession.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeSession.cs
@@ -51,7 +51,7 @@ namespace CleverTapSDK.Native {
         }
 
         internal string GetStorageKey(string suffix) {
-            return $"{UnityNativeAccountManager.Instance.AccountInfo.AccountId}:{suffix}";
+            return UnityNativeConstants.GetStorageKeyWithAccountId(suffix);
         }
 
         internal long GetNow() {

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeSession.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeSession.cs
@@ -4,20 +4,25 @@ using UnityEngine;
 
 namespace CleverTapSDK.Native {
     internal class UnityNativeSession {
-        private readonly long _sessionId;
-        private readonly bool _isFirstSession;
-        private readonly long _lastSessionLength;
+        private long _sessionId;
+        private bool _isFirstSession;
+        private long _lastSessionLength;
 
         private bool _isAppLaunched;
         private long _lastUpdateTimestamp;
 
         internal UnityNativeSession()
         {
+            _isAppLaunched = false;
+        }
+
+        internal void Initialize()
+        {
             long now = GetNow();
             _sessionId = now;
             _lastUpdateTimestamp = now;
-            _isAppLaunched = false;
 
+            // Use string to get/set long values in PlayerPrefs
             long lastSessionId = long.Parse(PlayerPrefs.GetString(GetStorageKey(UnityNativeConstants.Session.SESSION_ID), "0"));
             if (lastSessionId == 0)
             {
@@ -31,8 +36,10 @@ namespace CleverTapSDK.Native {
             }
 
             PlayerPrefs.SetString(GetStorageKey(UnityNativeConstants.Session.SESSION_ID), _sessionId.ToString());
+            HasInitialized = true;
         }
-        
+
+        internal bool HasInitialized { get; private set; }
         internal long SessionId => _sessionId;
         internal long LastSessionLength => _lastSessionLength;
         internal bool IsFirstSession => _isFirstSession;

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeUserEventQueue.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeUserEventQueue.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 namespace CleverTapSDK.Native {
     internal class UnityNativeUserEventQueue : UnityNativeBaseEventQueue {
 
+        protected override string QueueName => "USER_EVENTS";
+
         internal UnityNativeUserEventQueue(int queueLimit = 49, int defaultTimerInterval = 1) : base(queueLimit, defaultTimerInterval) { }
 
         protected override string RequestPath => UnityNativeConstants.Network.REQUEST_PATH_RECORD;

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeUserEventQueue.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeUserEventQueue.cs
@@ -1,7 +1,6 @@
 #if !UNITY_IOS && !UNITY_ANDROID
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using CleverTapSDK.Utilities;
 
 namespace CleverTapSDK.Native {
     internal class UnityNativeUserEventQueue : UnityNativeBaseEventQueue {
@@ -17,7 +16,6 @@ namespace CleverTapSDK.Native {
 
         protected override bool CanProcessEventResponse(UnityNativeResponse response)
         {
-            CleverTapLogger.Log("CanProcessEventResponse"+response.IsSuccess());
             return response.IsSuccess();
         }
     }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeDatabaseStore.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeDatabaseStore.cs
@@ -35,8 +35,7 @@ namespace CleverTapSDK.Native {
             }
         }
 
-        internal void AddEventsFromDB()
-        {
+        internal void AddEventsFromDB() {
             if (dataService == null)
             {
                 CleverTapLogger.LogError("Database not intiallised");
@@ -46,26 +45,31 @@ namespace CleverTapSDK.Native {
             CleverTapLogger.Log("Adding Cache events to processing queue from Database");
 
             List<UnityNativeEventDBEntry> entries = dataService.GetAllEntries<UnityNativeEventDBEntry>();
-           
-            foreach (var entry in entries)
+
+            if (OnEventStored != null)
             {
-                if (OnEventStored != null)
+                foreach (var entry in entries)
                 {
                     CleverTapLogger.Log($"Event added to Queue id: {entry.Id} type: {entry.EventType} jsonContent: {entry.JsonContent}");
                     OnEventStored(new UnityNativeEvent(entry.Id, entry));
                 }
-            }            
+            }
         }
 
         internal void DeleteEvents(List<UnityNativeEvent> eventsToRemove) {
-
             if (dataService == null)
             {
                 CleverTapLogger.LogError("Database not intiallised");
                 return;
             }
-            
-            foreach(var events in eventsToRemove)
+
+            if (eventsToRemove == null)
+            {
+                CleverTapLogger.Log("No events to remove");
+                return;
+            }
+
+            foreach (var events in eventsToRemove)
             {
                 int id =  events.Id ?? -1;
                 if (id != -1)

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventManager.cs
@@ -56,7 +56,7 @@ namespace CleverTapSDK.Native {
                 { UnityNativeConstants.Event.EVENT_NAME, UnityNativeConstants.Event.EVENT_APP_LUNACH }
             };
 
-            UnityNativeEvent @event = BuildEventWithAppFields(UnityNativeEventType.RecordEvent, eventDetails, false);
+            UnityNativeEvent @event = BuildEventWithAppFields(UnityNativeEventType.RaisedEvent, eventDetails, false);
             StoreEvent(@event);
             _eventQueueManager.FlushQueues();
         }
@@ -259,9 +259,9 @@ namespace CleverTapSDK.Native {
                 return null;
             }
 
-            var eventBuilderResult = new UnityNativeRecordEventBuilder().Build(eventName, properties);
+            var eventBuilderResult = new UnityNativeRaisedEventBuilder().Build(eventName, properties);
             var eventDetails = eventBuilderResult.EventResult;
-            return BuildEvent(UnityNativeEventType.RecordEvent, eventDetails);
+            return BuildEvent(UnityNativeEventType.RaisedEvent, eventDetails);
         }
 
         internal UnityNativeEvent RecordChargedEventWithDetailsAndItems(Dictionary<string, object> details, List<Dictionary<string, object>> items) {
@@ -273,9 +273,9 @@ namespace CleverTapSDK.Native {
                 return null;
             }
 
-            var eventBuilderResult = new UnityNativeRecordEventBuilder().BuildChargedEvent(details, items);
+            var eventBuilderResult = new UnityNativeRaisedEventBuilder().BuildChargedEvent(details, items);
             var eventDetails = eventBuilderResult.EventResult;
-            return BuildEvent(UnityNativeEventType.RecordEvent, eventDetails);
+            return BuildEvent(UnityNativeEventType.RaisedEvent, eventDetails);
         }
 
         #endregion

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventQueueManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventQueueManager.cs
@@ -7,15 +7,15 @@ namespace CleverTapSDK.Native {
         private readonly UnityNativeDatabaseStore _databaseStore;
 
         private readonly UnityNativeBaseEventQueue _userEventsQueue;
-        private readonly UnityNativeBaseEventQueue _recordEventsQueue;
+        private readonly UnityNativeBaseEventQueue _raisedEventsQueue;
 
         internal UnityNativeEventQueueManager(UnityNativeDatabaseStore databaseStore) {
             _databaseStore = databaseStore;
             _databaseStore.OnEventStored += OnDatabaseEventStored;
             _userEventsQueue = new UnityNativeUserEventQueue();
             _userEventsQueue.OnEventTimerTick += OnUserEventTimerTick;
-            _recordEventsQueue = new UnityNativeRecordEventQueue();
-            _recordEventsQueue.OnEventTimerTick += OnRecordEventTimerTick;
+            _raisedEventsQueue = new UnityNativeRaisedEventQueue();
+            _raisedEventsQueue.OnEventTimerTick += OnRaisedEventTimerTick;
         }
 
         private void OnDatabaseEventStored(UnityNativeEvent newEvent) {
@@ -23,8 +23,8 @@ namespace CleverTapSDK.Native {
                 case UnityNativeEventType.ProfileEvent:
                     _userEventsQueue.QueueEvent(newEvent);
                     break;
-                case UnityNativeEventType.RecordEvent:
-                    _recordEventsQueue.QueueEvent(newEvent);
+                case UnityNativeEventType.RaisedEvent:
+                    _raisedEventsQueue.QueueEvent(newEvent);
                     break;
                 default:
                     break;
@@ -34,15 +34,15 @@ namespace CleverTapSDK.Native {
         internal async void FlushQueues() {
             CleverTapLogger.Log("Flushing queues");
             await FlushUserEvents();
-            await FlushRecordEvents();
+            await FlushRaisedEvents();
         }
 
         private async void OnUserEventTimerTick() {
             await FlushUserEvents();
         }
 
-        private async void OnRecordEventTimerTick() {
-           await FlushRecordEvents();
+        private async void OnRaisedEventTimerTick() {
+           await FlushRaisedEvents();
         }
 
         private async Task FlushUserEvents() {
@@ -51,9 +51,9 @@ namespace CleverTapSDK.Native {
             _databaseStore.DeleteEvents(flushedEvents);
         }
 
-        private async Task FlushRecordEvents() {
+        private async Task FlushRaisedEvents() {
             CleverTapLogger.Log("Flushing record events");
-            var flushedEvents = await _recordEventsQueue.FlushEvents();
+            var flushedEvents = await _raisedEventsQueue.FlushEvents();
             _databaseStore.DeleteEvents(flushedEvents);
         }
     }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventQueueManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventQueueManager.cs
@@ -1,5 +1,6 @@
 #if !UNITY_IOS && !UNITY_ANDROID
 using System.Threading.Tasks;
+using CleverTapSDK.Utilities;
 
 namespace CleverTapSDK.Native {
     internal class UnityNativeEventQueueManager {
@@ -30,6 +31,12 @@ namespace CleverTapSDK.Native {
             }
         }
 
+        internal async void FlushQueues() {
+            CleverTapLogger.Log("Flushing queues");
+            await FlushUserEvents();
+            await FlushRecordEvents();
+        }
+
         private async void OnUserEventTimerTick() {
             await FlushUserEvents();
         }
@@ -39,18 +46,15 @@ namespace CleverTapSDK.Native {
         }
 
         private async Task FlushUserEvents() {
+            CleverTapLogger.Log("Flushing user events");
             var flushedEvents = await _userEventsQueue.FlushEvents();
             _databaseStore.DeleteEvents(flushedEvents);
         }
 
         private async Task FlushRecordEvents() {
+            CleverTapLogger.Log("Flushing record events");
             var flushedEvents = await _recordEventsQueue.FlushEvents();
             _databaseStore.DeleteEvents(flushedEvents);
-        }
-
-        public async void FlushQueue(){
-            await FlushUserEvents();
-            await FlushRecordEvents();
         }
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeNetworkEngine.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeNetworkEngine.cs
@@ -174,29 +174,28 @@ namespace CleverTapSDK.Native {
             var request = new UnityNativeRequest(UnityNativeConstants.Network.REQUEST_PATH_HAND_SHAKE, UnityNativeConstants.Network.REQUEST_GET);
             var response = await ExecuteRequest(request);
 
-            if (response.IsSuccess())
-            {
-                return ProcessIncomingHeaders(response);
-            }
-
-            return false;
+            return response.IsSuccess();
         }
 
         internal bool ProcessIncomingHeaders(UnityNativeResponse response) {
-            if (response.Headers.ContainsKey(UnityNativeConstants.Network.HEADER_DOMAIN_MUTE))
+            if (response != null && response.Headers != null)
             {
-                _mute = bool.Parse(response.Headers[UnityNativeConstants.Network.HEADER_DOMAIN_MUTE]);
-                if (_mute)
-                    return false;
-            }
+                if (response.Headers.ContainsKey(UnityNativeConstants.Network.HEADER_DOMAIN_MUTE))
+                {
+                    _mute = bool.Parse(response.Headers[UnityNativeConstants.Network.HEADER_DOMAIN_MUTE]);
+                    if (_mute)
+                        return false;
+                }
 
-            if (response.Headers.ContainsKey(UnityNativeConstants.Network.HEADER_DOMAIN_NAME))
-            {
-                string newDomain = response.Headers[UnityNativeConstants.Network.HEADER_DOMAIN_NAME];
-                if (!string.IsNullOrEmpty(newDomain)) {
-                    CleverTapLogger.Log($"Setting new domain name: {newDomain}");
-                    SetBaseURI(newDomain);
-                    SetRedirectDomain(newDomain);
+                if (response.Headers.ContainsKey(UnityNativeConstants.Network.HEADER_DOMAIN_NAME))
+                {
+                    string newDomain = response.Headers[UnityNativeConstants.Network.HEADER_DOMAIN_NAME];
+                    if (!string.IsNullOrEmpty(newDomain))
+                    {
+                        CleverTapLogger.Log($"Setting new domain name: {newDomain}");
+                        SetBaseURI(newDomain);
+                        SetRedirectDomain(newDomain);
+                    }
                 }
             }
 
@@ -289,7 +288,7 @@ namespace CleverTapSDK.Native {
                     var allHeaders = request.Headers.ToDictionary(x => x.Key, x => x.Value);
                     foreach (var header in _headers) {
                         // Do not overwrite existing headers
-                        if (allHeaders.ContainsKey(header.Key)) {
+                        if (!allHeaders.ContainsKey(header.Key)) {
                             allHeaders.Add(header.Key, header.Value);
                         }
                     }
@@ -331,7 +330,6 @@ namespace CleverTapSDK.Native {
         }
 
         private async Task<UnityNativeResponse> SendRequest(UnityNativeRequest request) {
-            //TODO: Add ping mechanism for network checks later
             if (Application.internetReachability == NetworkReachability.NotReachable)
             {
                 CleverTapLogger.LogError("Internet connection is not reachable!");
@@ -347,7 +345,7 @@ namespace CleverTapSDK.Native {
                     await Task.Yield();
                 }
 
-                if(unityWebRequest.result == UnityWebRequest.Result.Success)
+                if (unityWebRequest.result == UnityWebRequest.Result.Success)
                 {
                     responseFailureCount = 0;
                 }
@@ -362,7 +360,7 @@ namespace CleverTapSDK.Native {
                         return new UnityNativeResponse(request, (HttpStatusCode)unityWebRequest.responseCode, unityWebRequest.GetResponseHeaders(), unityWebRequest.downloadHandler.text);
 
                     case UnityWebRequest.Result.ConnectionError:
-                        CleverTapLogger.LogError("Failed ConnectionError");
+                        CleverTapLogger.LogError($"Failed ConnectionError: {(HttpStatusCode)unityWebRequest.responseCode}, error: {unityWebRequest.downloadHandler.text}, request: {request.RequestBody}");
                         return new UnityNativeResponse(request, HttpStatusCode.InternalServerError, null, null, "Internet connection is not reachable");
 
                     case UnityWebRequest.Result.ProtocolError:
@@ -379,7 +377,7 @@ namespace CleverTapSDK.Native {
                 }
 
             } catch (Exception ex) {
-                CleverTapLogger.LogError("Failed: "+ex.Message+" stcak"+ex.StackTrace+" "+ex.Data);
+                CleverTapLogger.LogError($"Failed: {ex.Message}, Stack Trace: {ex.StackTrace}, Data: {ex.Data}");
                 return new UnityNativeResponse(request, HttpStatusCode.InternalServerError, null, null, ex.Message);
             }
         }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeNetworkEngine.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeNetworkEngine.cs
@@ -340,6 +340,7 @@ namespace CleverTapSDK.Native {
 
             try {
                 var unityWebRequest = request.BuildRequest(_baseURI);
+                CleverTapLogger.Log("Sending web request");
                 // Workaround for async
                 var unityWebRequestAsyncOperation = unityWebRequest.SendWebRequest();
                 while (!unityWebRequestAsyncOperation.isDone) {
@@ -354,7 +355,6 @@ namespace CleverTapSDK.Native {
                 {
                     responseFailureCount++;
                 }
-
             
                 switch (unityWebRequest.result)
                 {

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativePreferenceManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativePreferenceManager.cs
@@ -76,7 +76,7 @@ namespace CleverTapSDK.Native {
         }
 
         internal string GetStorageKey(string suffix) {
-            return $"{UnityNativeAccountManager.Instance.AccountInfo.AccountId}:{suffix}";
+            return UnityNativeConstants.GetStorageKeyWithAccountId(suffix);
         }
 
         internal string GetKeyIdentifier(string key, string identifier) {

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativePreferenceManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativePreferenceManager.cs
@@ -10,7 +10,6 @@ namespace CleverTapSDK.Native {
         private List<string> _sessionKeys = new List<string>();
 
         internal UnityNativePreferenceManager() {
-
         }
 
         internal void GetSessionPreff(string key) {
@@ -34,41 +33,54 @@ namespace CleverTapSDK.Native {
 
         internal string GetGUIDForIdentifier(string key, string identifier)
         {
-           string cachedGUID = null;
-           string cachedIdentities = GetUserIdentities();
-           if(string.IsNullOrEmpty(cachedIdentities)){
+            string cachedGUID = null;
+            string cachedIdentities = GetUserIdentities();
+            if (string.IsNullOrEmpty(cachedIdentities))
+            {
                 return null;
-           }
-           string identKey = string.Format("{0}_{1}",key,identifier);
+            }
+            string identKey = GetKeyIdentifier(key, identifier);
             Dictionary<string, object> cachedValues = Json.Deserialize(cachedIdentities) as Dictionary<string, object>;
-            if (cachedValues.ContainsKey(identKey)){
-                cachedGUID = cachedValues[identKey].ToString();   
-           }
-           return cachedGUID;
+            if (cachedValues.ContainsKey(identKey))
+            {
+                cachedGUID = cachedValues[identKey].ToString();
+            }
+            return cachedGUID;
         }
 
-        internal string GetUserIdentities()
-        {
-           return PlayerPrefs.GetString(UnityNativeConstants.SDK.CACHED_GUIDS_KEY+UnityNativeAccountManager.Instance.AccountInfo.AccountId,null);
+        internal string GetUserIdentities() {
+           return PlayerPrefs.GetString(GetStorageKey(UnityNativeConstants.SDK.CACHED_GUIDS_KEY), null);
         }
+
         /// <summary>
         /// 
         /// </summary>
         /// <param name="guid">GUID</param>
         /// <param name="key">Key as in Email or Identity</param>
         /// <param name="identifier"> identifier value like abc@efg.com or 1212sdsk</param>
-        public void SetGUIDForIdentifier(string guid,string key,string identifier){
+        internal void SetGUIDForIdentifier(string guid, string key, string identifier) {
             string cachedIdentities = GetUserIdentities();
             Dictionary<string, object> cachedValues;
-            if (string.IsNullOrEmpty(cachedIdentities)){
+            if (string.IsNullOrEmpty(cachedIdentities))
+            {
                 cachedValues = new Dictionary<string, object>();
-           }else
-                cachedValues = Json.Deserialize(cachedIdentities) as Dictionary<string,object>;
+            }
+            else
+            {
+                cachedValues = Json.Deserialize(cachedIdentities) as Dictionary<string, object>;
+            }
 
-            cachedValues[string.Format("{0}_{1}",key,identifier)] = guid;
-            PlayerPrefs.SetString(UnityNativeConstants.SDK.CACHED_GUIDS_KEY+UnityNativeAccountManager.Instance.AccountInfo.AccountId,
+            cachedValues[GetKeyIdentifier(key, identifier)] = guid;
+            PlayerPrefs.SetString(GetStorageKey(UnityNativeConstants.SDK.CACHED_GUIDS_KEY),
                 Json.Serialize(cachedValues));
-         
+        }
+
+        internal string GetStorageKey(string suffix) {
+            return $"{UnityNativeAccountManager.Instance.AccountInfo.AccountId}:{suffix}";
+        }
+
+        internal string GetKeyIdentifier(string key, string identifier) {
+            return string.Format("{0}_{1}", key, identifier);
         }
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeSessionManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeSessionManager.cs
@@ -1,5 +1,6 @@
 ﻿#if !UNITY_IOS && !UNITY_ANDROID
 using System;
+using System.Collections.Generic;
 
 namespace CleverTapSDK.Native {
     internal class UnityNativeSessionManager {
@@ -17,16 +18,25 @@ namespace CleverTapSDK.Native {
 
         public UnityNativeSession CurrentSession {
             get {
-                if (IsSessionExpired()) {
-                    _currentSession = new UnityNativeSession();
+                if (_currentSession.HasInitialized && IsSessionExpired()) {
+                    ResetSession();
                 }
 
                 return _currentSession;
             }
         }
 
+        /// <summary>
+        /// Initializes the current session.
+        /// Requires AccountInfo to be set.
+        /// </summary>
+        internal void InitializeSession() {
+            CurrentSession.Initialize();
+        }
+
         internal void ResetSession() {
             _currentSession = new UnityNativeSession();
+            _currentSession.Initialize();
         }
 
         internal bool IsFirstSession() {

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeSessionManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeSessionManager.cs
@@ -10,7 +10,7 @@ namespace CleverTapSDK.Native {
         private UnityNativeSession _currentSession;
 
         private UnityNativeSessionManager() {
-            _currentSession = new UnityNativeSession(isFirstSession: true);
+            _currentSession = new UnityNativeSession();
         }
 
         internal static UnityNativeSessionManager Instance => instance.Value;
@@ -18,50 +18,57 @@ namespace CleverTapSDK.Native {
         public UnityNativeSession CurrentSession {
             get {
                 if (IsSessionExpired()) {
-                    _currentSession = new UnityNativeSession(userIdentity: _currentSession.UserIdentity);
+                    _currentSession = new UnityNativeSession();
                 }
 
                 return _currentSession;
             }
         }
 
+        internal void ResetSession() {
+            _currentSession = new UnityNativeSession();
+        }
+
         internal bool IsFirstSession() {
             return _currentSession.IsFirstSession;
         }
 
+        /// <summary>
+        /// Used for Page events only.
+        /// Increment when RecordScreenView is called.
+        /// Not supported yet.
+        /// </summary>
+        /// <returns>The screens count.</returns>
         internal int GetScreenCount() {
-            // TODO: Implement if needed
             return 1;
         }
 
-        internal long GetLastSessionLength() {
-            return DateTimeOffset.UtcNow.ToUnixTimeSeconds() - _currentSession.StartTimestamp;
+        /// <summary>
+        /// The current screen name.
+        /// Equivalent to the current Activity name on Android
+        /// and the current ViewController on iOS.
+        /// Not supported yet.
+        /// </summary>
+        /// <returns>The name of the current screen.</returns>
+        internal string GetScreenName()
+        {
+            return string.Empty;
         }
 
-        internal void UpdateSessionUserIdentity(string userIdentity) {
-            if (IsSessionExpired()) {
-                _currentSession = new UnityNativeSession(userIdentity: _currentSession.UserIdentity);
-            }
-
-            if (_currentSession.UserIdentity == null) {
-                _currentSession.SetUserIdentity(userIdentity);
-                _currentSession.UpdateTimestamp();
-            } else if (_currentSession.UserIdentity != null && _currentSession.UserIdentity != userIdentity) {
-                _currentSession = new UnityNativeSession(userIdentity: userIdentity);
-            }
+        internal long GetLastSessionLength() {
+            return _currentSession.LastSessionLength;
         }
 
         internal void UpdateSessionTimestamp() {
             if (IsSessionExpired()) {
-                _currentSession = new UnityNativeSession(userIdentity: _currentSession.UserIdentity);
+                _currentSession = new UnityNativeSession();
             }
 
             _currentSession?.UpdateTimestamp();
         }
 
         private bool IsSessionExpired() {
-            var currentTimestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-            return currentTimestamp - _currentSession.LastUpdateTimestamp > SESSION_LENGTH_SECONDS;
+            return _currentSession.GetNow() - _currentSession.LastUpdateTimestamp > SESSION_LENGTH_SECONDS;
         }
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeWrapper.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeWrapper.cs
@@ -5,9 +5,9 @@ namespace CleverTapSDK.Native {
     internal class UnityNativeWrapper {        
         private readonly UnityNativeEventManager _eventManager;
 
-        internal UnityNativeWrapper()
+        internal UnityNativeWrapper(UnityNativeCallbackHandler callbackHandler)
         {
-            _eventManager = new UnityNativeEventManager();
+            _eventManager = new UnityNativeEventManager(callbackHandler);
         }
 
         internal void LaunchWithCredentials(string accountID, string token, string region = null) {


### PR DESCRIPTION
## Overview 
Addressing the following issues:

1. Set `MonoHelper` namespace `CleverTapSDK.Common` to match the structure
2. Use a common SDK Version and revision for Unity Native and Wrapper
3. Refactor `DeviceInfo` properties. Add `EnableNetworkInfoReporting`.
4. Persist Session data correctly.
5. Add `Phone` to Identity Keys. Add logs for `OnUserLogin`.
6. `OnUserLogin` reset session, flush queues, and notify the profile is initialized. Send down the Callback Handler to the `UnityNativeEventManager`.
7. Process headers for redirecting domain on all requests. Persist the new domain.
8. Accept Date objects for properties. Remove the specific date format check.
9. Remove the unfinished `ValidateCleverTapId` logic. This is used for custom CleverTap Id which is not supported yet on Unity.
10. Clear not supported event builder meta from `UnityNativeMetaEventBuilder.cs`
11. Validate Charged items count > 50
12. Defer recording events and profile updates until `App Launched` is processed.
13. Fix retry logic. Send `App Launched` through the raised event queue. Set request default timeout.
14. Rename event type `RecordEvent` to `RaisedEvent` to match native SDKs and differentiate from the `RecordEvent(...)` methods.
15. Implement `ProfileRemoveValueForKey`

## Implementation
2. Add `SDK Revision` to `CleverTapVersion`. Set the `DeviceInfo` to use the `SDK Revision` for `sdkVersion` since the API works with the revision number. 
3. Implement `EnableNetworkInfoReporting` to enable the use of the IP address. Report `radio` and `wifi` if available. Persist the setting in `PlayerPrefs`.
4. `UnityNativeSession` - use `PlayerPrefs` to persist the session id, last time the session was updated and calculate the last session length. Update the session time when a request is made.
6. Use the `CallbackHandler` to notify the user profile initialized. Use the same message format as mobile SDKs. Set the `CallbackHandler` to `UnityNativeEventManager` from the platform binding through the `UnityNativeWrapper`.
7. Redirect domain header can be set to requests other than the handshake `/hello`. In fact, it is set to the response of the `App Launched` based on my tests. Persist the domain in `PlayerPrefs` and use it. If set, do not require a handshake.
12. Defer the recording of events until `App Launched` is processed. Previously those calls were ignored and lost. We need `App Launched` to be processed so it is the first event set and also SDK is initialized. Currently the important part is setting the `AccountId`. The `PlayerPrefs` storage uses keys based on the `AccountInfo` `AccountId`. This means the `AccountId` must be available when initializing data from `PlayerPrefs`. Defer the `Session`  initialization and move it out of the constructor.
13. Retry logic was _not_ working at all. `App Launched` was not retried.
Record `App Launched` through the raised events queue since it is a `RaisedEvent` and the queues have exponential retry logic.
Set the `IsAppLaunched` when the event is recorded, not when the request response is received. This mimics the mobile SDKs.
Fix the `UnityNativeEventBaseQueue` retry logic. It was getting stuck in the `while` loop. Retry was not working due to the `retry` flag always being `false`.
15. Use `value=1` and `$DELETE` command
