### PR TITLE
Define File variable fix

### DIFF
--- a/CleverTap/Runtime/Android/AndroidPlatformVariable.cs
+++ b/CleverTap/Runtime/Android/AndroidPlatformVariable.cs
@@ -16,15 +16,12 @@ namespace CleverTapSDK.Android {
             CleverTapAndroidJNI.CleverTapJNIInstance.Call("fetchVariables", callbackId);
 
         protected override Var<T> DefineVariable<T>(string name, string kind, T defaultValue) {
-            CleverTapAndroidJNI.CleverTapJNIInstance.Call("defineVar", name, kind, Json.Serialize(defaultValue));
+            if (kind == CleverTapVariableKind.FILE) {
+                CleverTapAndroidJNI.CleverTapJNIInstance.Call("defineFileVariable", name);
+            } else {
+                CleverTapAndroidJNI.CleverTapJNIInstance.Call("defineVar", name, kind, Json.Serialize(defaultValue));
+            }
             Var<T> result = new AndroidVar<T>(name, kind, defaultValue);
-            varCache.Add(name, result);
-            return result;
-        }
-
-        internal override Var<string> DefineFileVariable(string name) {
-            CleverTapAndroidJNI.CleverTapJNIInstance.Call("defineFileVariable", name);
-            Var<string> result = new AndroidVar<string>(name, CleverTapVariableKind.FILE, null);
             varCache.Add(name, result);
             return result;
         }

--- a/CleverTap/Runtime/Common/CleverTapPlatformVariable.cs
+++ b/CleverTap/Runtime/Common/CleverTapPlatformVariable.cs
@@ -103,12 +103,15 @@ namespace CleverTapSDK.Common {
         }
 
         protected virtual Var<string> GetOrDefineFileVariable(string name) {
-            
-            if (varCache.ContainsKey(name) && varCache[name].Kind.Equals(CleverTapVariableKind.FILE)) {
+            if (varCache.ContainsKey(name)) {
+                if (varCache[name].Kind != CleverTapVariableKind.FILE) {
+                    CleverTapLogger.LogError("CleverTap Error: Variable " + "\"" + name + "\" was already defined with a different kind");
+                    return null;
+                }
                 return (Var<string>)varCache[name];
             }
-            
-            return DefineFileVariable(name);
+
+            return DefineVariable<string>(name, CleverTapVariableKind.FILE, null);
         }
         
         protected virtual string GetKindNameFromGenericType<T>() {

--- a/CleverTap/Runtime/Common/CleverTapPlatformVariable.cs
+++ b/CleverTap/Runtime/Common/CleverTapPlatformVariable.cs
@@ -23,40 +23,40 @@ namespace CleverTapSDK.Common {
             return null;
         }
 
-        internal virtual Var<int> Define(string name, int defaultValue) =>
+        internal Var<int> Define(string name, int defaultValue) =>
             GetOrDefineVariable<int>(name, defaultValue);
 
-        internal virtual Var<long> Define(string name, long defaultValue) =>
+        internal Var<long> Define(string name, long defaultValue) =>
             GetOrDefineVariable<long>(name, defaultValue);
 
-        internal virtual Var<short> Define(string name, short defaultValue) =>
+        internal Var<short> Define(string name, short defaultValue) =>
             GetOrDefineVariable<short>(name, defaultValue);
 
-        internal virtual Var<byte> Define(string name, byte defaultValue) =>
+        internal Var<byte> Define(string name, byte defaultValue) =>
             GetOrDefineVariable<byte>(name, defaultValue);
 
-        internal virtual Var<bool> Define(string name, bool defaultValue) =>
+        internal Var<bool> Define(string name, bool defaultValue) =>
             GetOrDefineVariable<bool>(name, defaultValue);
 
-        internal virtual Var<float> Define(string name, float defaultValue) =>
+        internal Var<float> Define(string name, float defaultValue) =>
             GetOrDefineVariable<float>(name, defaultValue);
 
-        internal virtual Var<double> Define(string name, double defaultValue) =>
+        internal Var<double> Define(string name, double defaultValue) =>
             GetOrDefineVariable<double>(name, defaultValue);
 
-        internal virtual Var<string> Define(string name, string defaultValue) =>
+        internal Var<string> Define(string name, string defaultValue) =>
             GetOrDefineVariable<string>(name, defaultValue);
 
-        internal virtual Var<Dictionary<string, object>> Define(string name, Dictionary<string, object> defaultValue) =>
+        internal Var<Dictionary<string, object>> Define(string name, Dictionary<string, object> defaultValue) =>
             GetOrDefineVariable<Dictionary<string, object>>(name, defaultValue);
 
-        internal virtual Var<Dictionary<string, string>> Define(string name, Dictionary<string, string> defaultValue) =>
+        internal Var<Dictionary<string, string>> Define(string name, Dictionary<string, string> defaultValue) =>
             GetOrDefineVariable<Dictionary<string, string>>(name, defaultValue);
 
-        internal virtual Var<string> DefineFileVariable(string name) =>
+        internal Var<string> DefineFileVariable(string name) =>
             GetOrDefineFileVariable(name);
         
-        internal virtual void FetchVariables(Action<bool> isSucessCallback) {
+        internal void FetchVariables(Action<bool> isSucessCallback) {
             var callbackId = variablesFetchedIdCounter.GetNextAndIncreaseCounter();
             if (!variablesFetchedCallbacks.ContainsKey(callbackId)) {
                 variablesFetchedCallbacks.Add(callbackId, isSucessCallback);
@@ -64,21 +64,20 @@ namespace CleverTapSDK.Common {
             }
         }
 
-        internal virtual void VariablesFetched(int callbackId, bool isSuccess) {
+        internal void VariablesFetched(int callbackId, bool isSuccess) {
             if (variablesFetchedCallbacks.ContainsKey(callbackId)) {
                 variablesFetchedCallbacks[callbackId].Invoke(isSuccess);
                 variablesFetchedCallbacks.Remove(callbackId);
             }
         }
 
-        internal virtual void VariableFileIsReady(string name) {
-            if (varCache.ContainsKey(name))
-            {
+        internal void VariableFileIsReady(string name) {
+            if (varCache.ContainsKey(name)) {
                 varCache[name].FileIsReady();
             }
         }
         
-        internal virtual void VariableChanged(string name) {
+        internal void VariableChanged(string name) {
             if (varCache.ContainsKey(name)) {
                 varCache[name].ValueChanged();
             }

--- a/CleverTap/Runtime/IOS/IOSPlatformVariable.cs
+++ b/CleverTap/Runtime/IOS/IOSPlatformVariable.cs
@@ -15,15 +15,12 @@ namespace CleverTapSDK.IOS {
             IOSDllImport.CleverTap_fetchVariables(callbackId);
 
         protected override Var<T> DefineVariable<T>(string name, string kind, T defaultValue) {
-            IOSDllImport.CleverTap_defineVar(name, kind, Json.Serialize(defaultValue));
+            if (kind == CleverTapVariableKind.FILE) {
+                IOSDllImport.CleverTap_defineFileVar(name);
+            } else {
+                IOSDllImport.CleverTap_defineVar(name, kind, Json.Serialize(defaultValue));
+            }
             Var<T> result = new IOSVar<T>(name, kind, defaultValue);
-            varCache.Add(name, result);
-            return result;
-        }
-
-        internal override Var<string> DefineFileVariable(string name) {
-            IOSDllImport.CleverTap_defineFileVar(name);
-            Var<string> result = new IOSVar<string>(name, CleverTapVariableKind.FILE, null);
             varCache.Add(name, result);
             return result;
         }

--- a/CleverTap/Runtime/Native/UnityNativePlatformVariable.cs
+++ b/CleverTap/Runtime/Native/UnityNativePlatformVariable.cs
@@ -21,12 +21,6 @@ namespace CleverTapSDK.Native {
             return null;
         }
 
-        internal override Var<string> DefineFileVariable(string name)
-        {
-            CleverTapLogger.LogError("CleverTap Error: Define File Variable is not supported for this platform.");
-            return null;
-        }
-
         protected override Var<T> GetOrDefineVariable<T>(string name, T defaultValue) {
             CleverTapLogger.LogError("CleverTap Error: Define is not supported for this platform.");
             return null;


### PR DESCRIPTION
## Overview
Fix calling `DefineFileVariable` twice with the same name leading to exception trying to add the same key to the VarCache dictionary.
Fix calling `DefineFileVariable` overriding a variable if such was already defined with the same name but different kind (type).

## Implementation
The iOS and Android Platform Variables were overriding the main `DefineFileVariable` method hence overriding the `GetOrDefineFileVariable` method call.
Do not override the `DefineFileVariable` method.
Reuse the `DefineVariable<T>` abstract method.