### PR TITLE
iOS callbacks buffering

### DIFF
--- a/CleverTap/Plugins/iOS/CleverTapAppFunctionPresenter.h
+++ b/CleverTap/Plugins/iOS/CleverTapAppFunctionPresenter.h
@@ -1,9 +1,3 @@
-//
-//  CleverTapAppFunctionPresenter.h
-//
-//  Created by Nikola Zagorchev on 22.10.24.
-//
-
 #import <Foundation/Foundation.h>
 #import "CTTemplatePresenter.h"
 

--- a/CleverTap/Plugins/iOS/CleverTapAppFunctionPresenter.h
+++ b/CleverTap/Plugins/iOS/CleverTapAppFunctionPresenter.h
@@ -9,8 +9,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString * kCleverTapAppFunctionPresent = @"CleverTapAppFunctionPresent";
-
 @interface CleverTapAppFunctionPresenter : NSObject <CTTemplatePresenter>
 
 @end

--- a/CleverTap/Plugins/iOS/CleverTapAppFunctionPresenter.mm
+++ b/CleverTap/Plugins/iOS/CleverTapAppFunctionPresenter.mm
@@ -1,9 +1,3 @@
-//
-//  CleverTapAppFunctionPresenter.m
-//
-//  Created by Nikola Zagorchev on 22.10.24.
-//
-
 #import "CleverTapAppFunctionPresenter.h"
 #import "CleverTapUnityManager.h"
 #import "CleverTapMessageSender.h"

--- a/CleverTap/Plugins/iOS/CleverTapAppFunctionPresenter.mm
+++ b/CleverTap/Plugins/iOS/CleverTapAppFunctionPresenter.mm
@@ -6,11 +6,13 @@
 
 #import "CleverTapAppFunctionPresenter.h"
 #import "CleverTapUnityManager.h"
+#import "CleverTapMessageSender.h"
+#import "CleverTapUnityCallbackInfo.h"
 
 @implementation CleverTapAppFunctionPresenter
 
 - (void)onPresent:(nonnull CTTemplateContext *)context {
-    UnitySendMessage([kCleverTapGameObjectName UTF8String], [kCleverTapAppFunctionPresent UTF8String], [context.templateName UTF8String]);
+    [[CleverTapMessageSender sharedInstance] send:CleverTapUnityCallbackCustomFunctionPresent withMessage:context.templateName];
 }
 
 - (void)onCloseClicked:(nonnull CTTemplateContext *)context {

--- a/CleverTap/Plugins/iOS/CleverTapBinding.m
+++ b/CleverTap/Plugins/iOS/CleverTapBinding.m
@@ -127,16 +127,9 @@ char* clevertap_cStringCopy(const char* string) {
 
 #pragma mark - Admin
 
-void CleverTap_launchWithCredentials(const char* accountID, const char* token) {
-    [CleverTapUnityManager launchWithAccountID:clevertap_stringToNSString(accountID) andToken:clevertap_stringToNSString(token)];
-}
-
-void CleverTap_launchWithCredentialsForRegion(const char* accountID, const char* token, const char* region) {
-    [CleverTapUnityManager launchWithAccountID:clevertap_stringToNSString(accountID) token:clevertap_stringToNSString(token) region:clevertap_stringToNSString(region)];
-}
-
-void CleverTap_launchWithCredentialsForProxyServer(const char* accountID, const char* token, const char* proxyDomain, const char* spikyProxyDomain) {
-    [CleverTapUnityManager launchWithAccountID:clevertap_stringToNSString(accountID) token:clevertap_stringToNSString(token) proxyDomain:clevertap_stringToNSString(proxyDomain) spikyProxyDomain:clevertap_stringToNSString(spikyProxyDomain)];
+void CleverTap_onCallbackAdded(const char* callbackName) {
+    [[CleverTapUnityManager sharedInstance]
+     onCallbackAdded:clevertap_stringToNSString(callbackName)];
 }
 
 void CleverTap_setDebugLevel(int level) {
@@ -713,10 +706,4 @@ int16_t CleverTap_customTemplateGetShortArg(const char* templateName, const char
 int8_t CleverTap_customTemplateGetByteArg(const char* templateName, const char* argumentName) {
     return [[CleverTapUnityManager sharedInstance]
             customTemplateGetByteArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
-}
-
-void CleverTap_onCallbackAdded(const char* callbackName)
-{
-    [[CleverTapUnityManager sharedInstance]
-     onCallbackAdded:clevertap_stringToNSString(callbackName)];
 }

--- a/CleverTap/Plugins/iOS/CleverTapBinding.m
+++ b/CleverTap/Plugins/iOS/CleverTapBinding.m
@@ -345,7 +345,6 @@ char* CleverTap_userGetEventHistory() {
     return clevertap_cStringCopy([jsonString UTF8String]);
 }
 
-
 #pragma mark - User Session
 
 char* CleverTap_sessionGetUTMDetails() {
@@ -591,107 +590,91 @@ void CleverTap_isPushPermissionGranted() {
 
 #pragma mark - Variables
 
-void CleverTap_defineVar(const char* name, const char* kind, const char* value)
-{
+void CleverTap_defineVar(const char* name, const char* kind, const char* value) {
     [[CleverTapUnityManager sharedInstance] defineVar:clevertap_stringToNSString(name)
                                                  kind:clevertap_stringToNSString(kind)
                                       andDefaultValue:clevertap_stringToNSString(value)];
 }
 
-void CleverTap_defineFileVar(const char* name)
-{
+void CleverTap_defineFileVar(const char* name) {
     [[CleverTapUnityManager sharedInstance] defineFileVar:clevertap_stringToNSString(name)];
 }
 
-char* CleverTap_getVariableValue(const char* name)
-{
+char* CleverTap_getVariableValue(const char* name) {
     NSString* json = [[CleverTapUnityManager sharedInstance]
                       getVariableValue:clevertap_stringToNSString(name)];
     return clevertap_cStringCopy([json UTF8String]);
 }
 
-char* CleverTap_getFileVariableValue(const char* name)
-{
+char* CleverTap_getFileVariableValue(const char* name) {
     NSString* json = [[CleverTapUnityManager sharedInstance]
                       getFileVariableValue:clevertap_stringToNSString(name)];
     return clevertap_cStringCopy([json UTF8String]);
 }
 
-void CleverTap_syncVariables()
-{
+void CleverTap_syncVariables() {
     [[CleverTapUnityManager sharedInstance] syncVariables];
 }
 
-void CleverTap_syncVariablesProduction(const BOOL isProduction)
-{
+void CleverTap_syncVariablesProduction(const BOOL isProduction) {
     [[CleverTapUnityManager sharedInstance] syncVariables: isProduction];
 }
 
-void CleverTap_fetchVariables(int callbackId)
-{
+void CleverTap_fetchVariables(int callbackId) {
     [[CleverTapUnityManager sharedInstance] fetchVariables:callbackId];
 }
 
 #pragma mark - Client-side In-Apps
-void CleverTap_fetchInApps(int callbackId)
-{
+
+void CleverTap_fetchInApps(int callbackId) {
     [[CleverTapUnityManager sharedInstance] fetchInApps:callbackId];
 }
 
-void CleverTap_clearInAppResources(const BOOL expiredOnly)
-{
+void CleverTap_clearInAppResources(const BOOL expiredOnly) {
     [[CleverTapUnityManager sharedInstance] clearInAppResources:expiredOnly];
 }
 
 #pragma mark - Custom Templates
 
-void CleverTap_customTemplateSetPresented(const char* name)
-{
+void CleverTap_customTemplateSetPresented(const char* name) {
     [[CleverTapUnityManager sharedInstance]
                       customTemplateSetPresented:clevertap_stringToNSString(name)];
 }
 
-void CleverTap_customTemplateSetDismissed(const char* name)
-{
+void CleverTap_customTemplateSetDismissed(const char* name) {
     [[CleverTapUnityManager sharedInstance]
                       customTemplateSetDismissed:clevertap_stringToNSString(name)];
 }
 
-char* CleverTap_customTemplateContextToString(const char* name)
-{
+char* CleverTap_customTemplateContextToString(const char* name) {
     NSString* value = [[CleverTapUnityManager sharedInstance]
                        customTemplateContextToString:clevertap_stringToNSString(name)];
     return clevertap_cStringCopy([value UTF8String]);
 }
 
-void CleverTap_customTemplateTriggerAction(const char* templateName, const char* argumentName)
-{
+void CleverTap_customTemplateTriggerAction(const char* templateName, const char* argumentName) {
     [[CleverTapUnityManager sharedInstance]
      customTemplateTriggerAction:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
 }
 
-char* CleverTap_customTemplateGetStringArg(const char* templateName, const char* argumentName)
-{
+char* CleverTap_customTemplateGetStringArg(const char* templateName, const char* argumentName) {
     NSString* value = [[CleverTapUnityManager sharedInstance]
                       customTemplateGetStringArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
     return clevertap_cStringCopy([value UTF8String]);
 }
 
-bool CleverTap_customTemplateGetBooleanArg(const char* templateName, const char* argumentName)
-{
+bool CleverTap_customTemplateGetBooleanArg(const char* templateName, const char* argumentName) {
     return [[CleverTapUnityManager sharedInstance]
                        customTemplateGetBooleanArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
 }
 
-char* CleverTap_customTemplateGetFileArg(const char* templateName, const char* argumentName)
-{
+char* CleverTap_customTemplateGetFileArg(const char* templateName, const char* argumentName) {
     NSString* value = [[CleverTapUnityManager sharedInstance]
                        customTemplateGetFileArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
     return clevertap_cStringCopy([value UTF8String]);
 }
 
-char* CleverTap_customTemplateGetDictionaryArg(const char* templateName, const char* argumentName)
-{
+char* CleverTap_customTemplateGetDictionaryArg(const char* templateName, const char* argumentName) {
     NSDictionary* json = [[CleverTapUnityManager sharedInstance]
                        customTemplateGetDictionaryArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
     NSString *jsonString = clevertap_toJsonString(json);
@@ -702,38 +685,32 @@ char* CleverTap_customTemplateGetDictionaryArg(const char* templateName, const c
     return clevertap_cStringCopy([jsonString UTF8String]);
 }
 
-int CleverTap_customTemplateGetIntArg(const char* templateName, const char* argumentName)
-{
+int CleverTap_customTemplateGetIntArg(const char* templateName, const char* argumentName) {
     return [[CleverTapUnityManager sharedInstance]
             customTemplateGetIntArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
 }
 
-double CleverTap_customTemplateGetDoubleArg(const char* templateName, const char* argumentName)
-{
+double CleverTap_customTemplateGetDoubleArg(const char* templateName, const char* argumentName) {
     return [[CleverTapUnityManager sharedInstance]
             customTemplateGetDoubleArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
 }
 
-float CleverTap_customTemplateGetFloatArg(const char* templateName, const char* argumentName)
-{
+float CleverTap_customTemplateGetFloatArg(const char* templateName, const char* argumentName) {
     return [[CleverTapUnityManager sharedInstance]
             customTemplateGetFloatArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
 }
 
-int64_t CleverTap_customTemplateGetLongArg(const char* templateName, const char* argumentName)
-{
+int64_t CleverTap_customTemplateGetLongArg(const char* templateName, const char* argumentName) {
     return [[CleverTapUnityManager sharedInstance]
             customTemplateGetLongArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
 }
 
-int16_t CleverTap_customTemplateGetShortArg(const char* templateName, const char* argumentName)
-{
+int16_t CleverTap_customTemplateGetShortArg(const char* templateName, const char* argumentName) {
     return [[CleverTapUnityManager sharedInstance]
             customTemplateGetShortArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
 }
 
-int8_t CleverTap_customTemplateGetByteArg(const char* templateName, const char* argumentName)
-{
+int8_t CleverTap_customTemplateGetByteArg(const char* templateName, const char* argumentName) {
     return [[CleverTapUnityManager sharedInstance]
             customTemplateGetByteArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
 }

--- a/CleverTap/Plugins/iOS/CleverTapBinding.m
+++ b/CleverTap/Plugins/iOS/CleverTapBinding.m
@@ -737,3 +737,9 @@ int8_t CleverTap_customTemplateGetByteArg(const char* templateName, const char* 
     return [[CleverTapUnityManager sharedInstance]
             customTemplateGetByteArg:clevertap_stringToNSString(templateName) named:clevertap_stringToNSString(argumentName)];
 }
+
+void CleverTap_onCallbackAdded(const char* callbackName)
+{
+    [[CleverTapUnityManager sharedInstance]
+     onCallbackAdded:clevertap_stringToNSString(callbackName)];
+}

--- a/CleverTap/Plugins/iOS/CleverTapCustomTemplates.h
+++ b/CleverTap/Plugins/iOS/CleverTapCustomTemplates.h
@@ -1,9 +1,3 @@
-//
-//  CleverTapCustomTemplates.h
-//
-//  Created by Nikola Zagorchev on 22.10.24.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/CleverTap/Plugins/iOS/CleverTapCustomTemplates.mm
+++ b/CleverTap/Plugins/iOS/CleverTapCustomTemplates.mm
@@ -1,9 +1,3 @@
-//
-//  CleverTapCustomTemplates.m
-//
-//  Created by Nikola Zagorchev on 22.10.24.
-//
-
 #import "CleverTapCustomTemplates.h"
 #import "CleverTapTemplatePresenter.h"
 #import "CleverTapAppFunctionPresenter.h"

--- a/CleverTap/Plugins/iOS/CleverTapMessageBuffer.h
+++ b/CleverTap/Plugins/iOS/CleverTapMessageBuffer.h
@@ -1,9 +1,3 @@
-//
-//  CleverTapMessageBuffer.h
-//
-//  Created by Nikola Zagorchev on 12.11.24.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -15,8 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithEnabled:(BOOL)isEnabled;
 
-- (void)add:(NSString *)item;
-- (nullable NSString *)remove;
+- (void)addItem:(NSString *)item;
+- (nullable NSString *)popItem;
 - (NSUInteger)count;
 
 @end

--- a/CleverTap/Plugins/iOS/CleverTapMessageBuffer.h
+++ b/CleverTap/Plugins/iOS/CleverTapMessageBuffer.h
@@ -1,0 +1,24 @@
+//
+//  CleverTapMessageBuffer.h
+//
+//  Created by Nikola Zagorchev on 12.11.24.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CleverTapMessageBuffer : NSObject
+
+@property (nonatomic, assign) BOOL isEnabled;
+@property (nonatomic, strong) NSMutableArray *items;
+
+- (instancetype)initWithEnabled:(BOOL)isEnabled;
+
+- (void)add:(NSString *)item;
+- (nullable NSString *)remove;
+- (NSUInteger)count;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTap/Plugins/iOS/CleverTapMessageBuffer.h.meta
+++ b/CleverTap/Plugins/iOS/CleverTapMessageBuffer.h.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: ff81ad3bdbb0945909e03bbc65283c9b
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapMessageBuffer.m
+++ b/CleverTap/Plugins/iOS/CleverTapMessageBuffer.m
@@ -1,9 +1,3 @@
-//
-//  CleverTapMessageBuffer.m
-//
-//  Created by Nikola Zagorchev on 12.11.24.
-//
-
 #import "CleverTapMessageBuffer.h"
 
 @implementation CleverTapMessageBuffer
@@ -16,13 +10,13 @@
     return self;
 }
 
-- (void)add:(NSString *)item {
+- (void)addItem:(NSString *)item {
     if (item) {
         [self.items addObject:item];
     }
 }
 
-- (nullable NSString *)remove {
+- (nullable NSString *)popItem {
     if (self.items.count > 0) {
         NSString *last = [self.items lastObject];
         [self.items removeLastObject];

--- a/CleverTap/Plugins/iOS/CleverTapMessageBuffer.m
+++ b/CleverTap/Plugins/iOS/CleverTapMessageBuffer.m
@@ -1,0 +1,38 @@
+//
+//  CleverTapMessageBuffer.m
+//
+//  Created by Nikola Zagorchev on 12.11.24.
+//
+
+#import "CleverTapMessageBuffer.h"
+
+@implementation CleverTapMessageBuffer
+
+- (instancetype)initWithEnabled:(BOOL)isEnabled {
+    if (self = [super init]) {
+        self.isEnabled = isEnabled;
+        self.items = [NSMutableArray array];
+    }
+    return self;
+}
+
+- (void)add:(NSString *)item {
+    if (item) {
+        [self.items addObject:item];
+    }
+}
+
+- (nullable NSString *)remove {
+    if (self.items.count > 0) {
+        NSString *last = [self.items lastObject];
+        [self.items removeLastObject];
+        return last;
+    }
+    return nil;
+}
+
+- (NSUInteger)count {
+    return self.items.count;
+}
+
+@end

--- a/CleverTap/Plugins/iOS/CleverTapMessageBuffer.m.meta
+++ b/CleverTap/Plugins/iOS/CleverTapMessageBuffer.m.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: de5700c2112664cb386d2bfc4c7756b2
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.h
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.h
@@ -1,9 +1,3 @@
-//
-//  CleverTapMessageSender.h
-//
-//  Created by Nikola Zagorchev on 12.11.24.
-//
-
 #import <Foundation/Foundation.h>
 #import "CleverTapUnityCallbackInfo.h"
 

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.h
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.h
@@ -1,0 +1,23 @@
+//
+//  CleverTapMessageSender.h
+//
+//  Created by Nikola Zagorchev on 12.11.24.
+//
+
+#import <Foundation/Foundation.h>
+#import "CleverTapUnityCallbackInfo.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CleverTapMessageSender : NSObject
+
++ (instancetype)sharedInstance;
+
+- (void)send:(CleverTapUnityCallback)callback withMessage:(NSString *)message;
+- (void)flushBuffer:(CleverTapUnityCallbackInfo *)callbackInfo;
+- (void)disableBuffer:(CleverTapUnityCallbackInfo *)callbackInfo;
+- (void)resetAllBuffers;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.h.meta
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.h.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: ce76ccb5328394cd29dbe3af8c59558b
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.m
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.m
@@ -1,0 +1,87 @@
+//
+//  CleverTapMessageSender.m
+//
+//  Created by Nikola Zagorchev on 12.11.24.
+//
+
+#import "CleverTapMessageSender.h"
+#import "CleverTapUnityCallbackInfo.h"
+#import "CleverTapMessageBuffer.h"
+
+static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
+
+@interface CleverTapMessageSender()
+
+@property NSDictionary<CleverTapUnityCallbackInfo *, CleverTapMessageBuffer *> *messageBuffers;
+
+@end
+
+@implementation CleverTapMessageSender
+
++ (instancetype)sharedInstance {
+    static dispatch_once_t once = 0;
+    static id _sharedObject = nil;
+    dispatch_once(&once, ^{
+        _sharedObject = [[self alloc] init];
+    });
+    return _sharedObject;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        self.messageBuffers = [self createBuffers:YES];
+    }
+    return self;
+}
+
+- (NSDictionary<CleverTapUnityCallbackInfo *, CleverTapMessageBuffer *> *)createBuffers:(BOOL)enabled {
+    NSMutableDictionary<CleverTapUnityCallbackInfo *, CleverTapMessageBuffer *> *buffers = [NSMutableDictionary dictionary];
+    NSArray *callbackInfos = [CleverTapUnityCallbackInfo callbackInfos];
+    for (CleverTapUnityCallbackInfo *info in callbackInfos) {
+        if (info.isBufferable) {
+            buffers[info] = [[CleverTapMessageBuffer alloc] initWithEnabled:enabled];
+        }
+    }
+    return [NSDictionary dictionaryWithDictionary:buffers];
+}
+
+- (void)send:(CleverTapUnityCallback)callback withMessage:(NSString *)message {
+    CleverTapUnityCallbackInfo *callbackInfo = [CleverTapUnityCallbackInfo infoForCallback:callback];
+    if (callbackInfo.isBufferable) {
+        CleverTapMessageBuffer *buffer = self.messageBuffers[callbackInfo];
+        if (buffer.isEnabled) {
+            [buffer add:message];
+            return;
+        }
+    }
+    [self sendToUnity:callbackInfo withMessage:message];
+}
+
+- (void)sendToUnity:(CleverTapUnityCallbackInfo *)callbackInfo withMessage:(NSString *)message {
+    UnitySendMessage([kCleverTapGameObjectName UTF8String], [callbackInfo.callbackName UTF8String], [message UTF8String]);
+}
+
+- (void)flushBuffer:(CleverTapUnityCallbackInfo *)callbackInfo {
+    CleverTapMessageBuffer *buffer = self.messageBuffers[callbackInfo];
+    if (!buffer) {
+        return;
+    }
+    
+    while (buffer.count > 0) {
+        NSString *message = [buffer remove];
+        [self sendToUnity:callbackInfo withMessage:message];
+    }
+}
+
+- (void)disableBuffer:(CleverTapUnityCallbackInfo *)callbackInfo {
+    CleverTapMessageBuffer *buffer = self.messageBuffers[callbackInfo];
+    if (buffer) {
+        [buffer setIsEnabled:NO];
+    }
+}
+
+- (void)resetAllBuffers {
+    self.messageBuffers = [self createBuffers:NO];
+}
+
+@end

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.m
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.m
@@ -42,18 +42,19 @@ static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
 - (void)send:(CleverTapUnityCallback)callback withMessage:(NSString *)message {
     @synchronized (self) {
         CleverTapUnityCallbackInfo *callbackInfo = [CleverTapUnityCallbackInfo infoForCallback:callback];
-        if (callbackInfo.isBufferable) {
-            CleverTapMessageBuffer *buffer = self.messageBuffers[callbackInfo];
-            if (buffer.isEnabled) {
-                [buffer addItem:message];
-                return;
-            }
+        CleverTapMessageBuffer *buffer = self.messageBuffers[callbackInfo];
+        if (callbackInfo.isBufferable && buffer.isEnabled) {
+            [buffer addItem:message];
+            return;
         }
         [self sendToUnity:callbackInfo withMessage:message];
     }
 }
 
 - (void)sendToUnity:(CleverTapUnityCallbackInfo *)callbackInfo withMessage:(NSString *)message {
+    if (!callbackInfo) {
+        NSLog(@"Cannot send message for nil callback.");
+    }
     if (!message) {
         NSLog(@"Cannot send nil message to Unity. Callback: %@.", callbackInfo.callbackName);
         return;

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.m
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.m
@@ -39,7 +39,6 @@ static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
     return [NSDictionary dictionaryWithDictionary:buffers];
 }
 
-// TODO: synchronized
 - (void)send:(CleverTapUnityCallback)callback withMessage:(NSString *)message {
     @synchronized (self) {
         CleverTapUnityCallbackInfo *callbackInfo = [CleverTapUnityCallbackInfo infoForCallback:callback];

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.m.meta
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.m.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: ceef76cd71571472eb6982e43eebd010
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.h
+++ b/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.h
@@ -9,9 +9,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString * kCleverTapCustomTemplatePresent = @"CleverTapCustomTemplatePresent";
-static NSString * kCleverTapCustomTemplateClose = @"CleverTapCustomTemplateClose";
-
 @interface CleverTapTemplatePresenter : NSObject <CTTemplatePresenter>
 
 @end

--- a/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.h
+++ b/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.h
@@ -1,9 +1,3 @@
-//
-//  CleverTapTemplatePresenter.h
-//
-//  Created by Nikola Zagorchev on 22.10.24.
-//
-
 #import <Foundation/Foundation.h>
 #import "CTTemplatePresenter.h"
 

--- a/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.mm
+++ b/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.mm
@@ -6,15 +6,17 @@
 
 #import "CleverTapTemplatePresenter.h"
 #import "CleverTapUnityManager.h"
+#import "CleverTapMessageSender.h"
+#import "CleverTapUnityCallbackInfo.h"
 
 @implementation CleverTapTemplatePresenter
 
-- (void)onPresent:(nonnull CTTemplateContext *)context { 
-    UnitySendMessage([kCleverTapGameObjectName UTF8String], [kCleverTapCustomTemplatePresent UTF8String], [context.templateName UTF8String]);
+- (void)onPresent:(nonnull CTTemplateContext *)context {
+    [[CleverTapMessageSender sharedInstance] send:CleverTapUnityCallbackCustomTemplateClose withMessage:context.templateName];
 }
 
 - (void)onCloseClicked:(nonnull CTTemplateContext *)context {
-    UnitySendMessage([kCleverTapGameObjectName UTF8String], [kCleverTapCustomTemplateClose UTF8String], [context.templateName UTF8String]);
+    [[CleverTapMessageSender sharedInstance] send:CleverTapUnityCallbackCustomTemplateClose withMessage:context.templateName];
 }
 
 @end

--- a/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.mm
+++ b/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.mm
@@ -1,9 +1,3 @@
-//
-//  CleverTapTemplatePresenter.m
-//
-//  Created by Nikola Zagorchev on 22.10.24.
-//
-
 #import "CleverTapTemplatePresenter.h"
 #import "CleverTapUnityManager.h"
 #import "CleverTapMessageSender.h"

--- a/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.mm
+++ b/CleverTap/Plugins/iOS/CleverTapTemplatePresenter.mm
@@ -6,7 +6,7 @@
 @implementation CleverTapTemplatePresenter
 
 - (void)onPresent:(nonnull CTTemplateContext *)context {
-    [[CleverTapMessageSender sharedInstance] send:CleverTapUnityCallbackCustomTemplateClose withMessage:context.templateName];
+    [[CleverTapMessageSender sharedInstance] send:CleverTapUnityCallbackCustomTemplatePresent withMessage:context.templateName];
 }
 
 - (void)onCloseClicked:(nonnull CTTemplateContext *)context {

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+#import "UnityAppController.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CleverTapUnityAppController : UnityAppController
+
+@end
+
+IMPL_APP_CONTROLLER_SUBCLASS(CleverTapUnityAppController)
+
+NS_ASSUME_NONNULL_END

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.h.meta
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.h.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: 6b548c2aed93848108aa1fbf56f75914
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
@@ -1,0 +1,14 @@
+#import "CleverTapUnityAppController.h"
+#import "CleverTapUnityManager.h"
+#import <CleverTapSDK/CleverTap.h>
+
+@implementation CleverTapUnityAppController
+
+- (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
+    
+    [CleverTap autoIntegrate];
+    [CleverTapUnityManager sharedInstance];
+    return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+@end

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.m.meta
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.m.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: f07f64144a8a749d785b1c3500ca30f8
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.h
@@ -1,0 +1,36 @@
+//
+//  CleverTapUnityCallbackHandler.h
+//
+//  Created by Nikola Zagorchev on 11.11.24.
+//
+
+#import <Foundation/Foundation.h>
+#import <CleverTapSDK/CleverTap+Inbox.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CleverTapUnityCallbackHandler : NSObject
+
++ (instancetype)sharedInstance;
+
+- (void)pushPermissionCallback:(BOOL)isPushEnabled;
+
+- (CleverTapFetchVariablesBlock)fetchVariablesBlock:(int)callbackId;
+
+- (CleverTapVariablesChangedBlock)variableValueChanged:(NSString *)varName;
+
+- (CleverTapVariablesChangedBlock)variableFileIsReady:(NSString *)varName;
+
+- (CleverTapFetchInAppsBlock)fetchInAppsBlock:(int)callbackId;
+    
+- (CleverTapInboxSuccessBlock)initializeInboxBlock;
+
+- (CleverTapInboxUpdatedBlock)inboxUpdatedBlock;
+
+- (void)didReceiveRemoteNotification:(UIApplicationState)applicationState data:(NSData *)data;
+    
+- (void)deepLinkCallback:(NSString *)url;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.h
@@ -1,17 +1,25 @@
-//
-//  CleverTapUnityCallbackHandler.h
-//
-//  Created by Nikola Zagorchev on 11.11.24.
-//
-
 #import <Foundation/Foundation.h>
 #import <CleverTapSDK/CleverTap+Inbox.h>
+#import <CleverTapSDK/CleverTap.h>
+#import <CleverTapSDK/CleverTapSyncDelegate.h>
+#import <CleverTapSDK/CleverTap+DisplayUnit.h>
+#import <CleverTapSDK/CleverTap+FeatureFlags.h>
+#import <CleverTapSDK/CleverTap+ProductConfig.h>
+#import <CleverTapSDK/CleverTapInAppNotificationDelegate.h>
+#import <CleverTapSDK/Clevertap+PushPermission.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CleverTapUnityCallbackHandler : NSObject
+@interface CleverTapUnityCallbackHandler : NSObject 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+<CleverTapInAppNotificationDelegate, CleverTapDisplayUnitDelegate, CleverTapInboxViewControllerDelegate, CleverTapProductConfigDelegate, CleverTapFeatureFlagsDelegate, CleverTapPushPermissionDelegate>
+
+#pragma clang diagnostic pop
 
 + (instancetype)sharedInstance;
+
+- (void)attachInstance:(CleverTap *)instance;
 
 - (void)pushPermissionCallback:(BOOL)isPushEnabled;
 

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.h.meta
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.h.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: 10e374d8b4e7b490994fe442c63a0a1f
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.mm
@@ -1,0 +1,301 @@
+//
+//  CleverTapUnityCallbackHandler.m
+//
+//  Created by Nikola Zagorchev on 11.11.24.
+//
+
+#import "CleverTapUnityCallbackHandler.h"
+#import "CleverTapUnityCallbackInfo.h"
+#import "CleverTapMessageSender.h"
+#import <CleverTapSDK/CleverTap.h>
+#import <CleverTapSDK/CleverTapSyncDelegate.h>
+#import <CleverTapSDK/CleverTap+DisplayUnit.h>
+#import <CleverTapSDK/CleverTap+FeatureFlags.h>
+#import <CleverTapSDK/CleverTap+ProductConfig.h>
+#import <CleverTapSDK/CleverTapInAppNotificationDelegate.h>
+#import <CleverTapSDK/Clevertap+PushPermission.h>
+
+@interface CleverTapUnityCallbackHandler () <CleverTapInAppNotificationDelegate, CleverTapDisplayUnitDelegate, CleverTapInboxViewControllerDelegate, CleverTapProductConfigDelegate, CleverTapFeatureFlagsDelegate, CleverTapPushPermissionDelegate>
+
+@end
+
+@implementation CleverTapUnityCallbackHandler
+
++ (instancetype)sharedInstance {
+    static dispatch_once_t once = 0;
+    static id _sharedObject = nil;
+    dispatch_once(&once, ^{
+        _sharedObject = [[self alloc] init];
+    });
+    return _sharedObject;
+}
+
+- (void)callUnityObject:(CleverTapUnityCallback)callback withMessage:(NSString *)message {
+    [[CleverTapMessageSender sharedInstance] send:callback withMessage:message];
+}
+
+- (void)attachInstance:(CleverTap *)instance {
+    [self registerListeners];
+    
+    [instance setInAppNotificationDelegate:self];
+    [instance setDisplayUnitDelegate:self];
+    [instance setPushPermissionDelegate:self];
+    
+    [instance onVariablesChanged:[self variablesChanged]];
+    [instance onVariablesChangedAndNoDownloadsPending:[self variablesChangedAndNoDownloadsPending]];
+    
+    [[instance productConfig] setDelegate:self];
+    [[instance featureFlags] setDelegate:self];
+}
+
+- (CleverTapVariablesChangedBlock)variablesChanged {
+    return ^{
+        [self callUnityObject:CleverTapUnityCallbackVariablesChanged withMessage:@"VariablesChanged"];
+    };
+}
+
+- (CleverTapVariablesChangedBlock)variablesChangedAndNoDownloadsPending {
+    return ^{
+        [self callUnityObject:CleverTapUnityCallbackVariablesChangedAndNoDownloadsPending withMessage:@"VariablesChangedAndNoDownloadsPending"];
+    };
+}
+
+- (CleverTapFetchVariablesBlock)fetchVariablesBlock:(int)callbackId {
+    return ^(BOOL success) {
+        NSDictionary* response = @{
+            @"callbackId": @(callbackId),
+            @"isSuccess": @(success)
+        };
+        
+        NSString* json = [self dictToJson:response];
+        [self callUnityObject:CleverTapUnityCallbackVariablesFetched withMessage:json];
+    };
+}
+
+- (CleverTapFetchInAppsBlock)fetchInAppsBlock:(int)callbackId {
+    return ^(BOOL success) {
+        NSDictionary* response = @{
+            @"callbackId": @(callbackId),
+            @"isSuccess": @(success)
+        };
+        
+        NSString* json = [self dictToJson:response];
+        [self callUnityObject:CleverTapUnityCallbackInAppsFetched withMessage:json];
+    };
+}
+
+- (void)pushPermissionCallback:(BOOL)isPushEnabled {
+    [self callUnityObject:CleverTapUnityCallbackPushNotificationPermissionStatus withMessage:[NSString stringWithFormat:@"%@", isPushEnabled? @"True": @"False"]];
+}
+
+- (CleverTapVariablesChangedBlock)variableValueChanged:(NSString *)varName {
+    return ^{
+        [self callUnityObject:CleverTapUnityCallbackVariableValueChanged withMessage:varName];
+    };
+}
+
+- (CleverTapVariablesChangedBlock)variableFileIsReady:(NSString *)varName {
+    return ^{
+        [self callUnityObject:CleverTapUnityCallbackVariableFileIsReady withMessage:varName];
+    };
+}
+
+- (CleverTapInboxSuccessBlock)initializeInboxBlock {
+    return ^(BOOL success) {
+        NSLog(@"Inbox initialized %d", success);
+        [self callUnityObject:CleverTapUnityCallbackInboxDidInitialize withMessage:[NSString stringWithFormat:@"%@", success? @"YES": @"NO"]];
+    };
+}
+
+- (CleverTapInboxUpdatedBlock)inboxUpdatedBlock {
+    return ^{
+        NSLog(@"Inbox Messages updated");
+        [self callUnityObject:CleverTapUnityCallbackInboxMessagesDidUpdate withMessage:@"inbox updated."];
+    };
+}
+
+- (void)didReceiveRemoteNotification:(UIApplicationState)applicationState data:(NSData *)data {
+    NSString *dataString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+    
+    CleverTapUnityCallback callback = (applicationState == UIApplicationStateActive) ? CleverTapUnityCallbackPushReceived : CleverTapUnityCallbackPushOpened;
+    
+    [self callUnityObject:callback withMessage:dataString];
+}
+
+- (void)deepLinkCallback:(NSString *)url {
+    [self callUnityObject:CleverTapUnityCallbackDeepLink withMessage:url];
+}
+
+- (NSString *)dictToJson:(NSDictionary *)dict {
+    NSError *err;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dict options:0 error:&err];
+    
+    if(err != nil) {
+        return nil;
+    }
+    
+    return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+}
+
+- (void)dealloc {
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+#pragma mark - CleverTapSyncDelegate/Listener
+
+- (void)registerListeners {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(didReceiveCleverTapProfileDidChangeNotification:)
+                                                 name:CleverTapProfileDidChangeNotification object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(didReceiveCleverTapProfileDidInitializeNotification:)
+                                                 name:CleverTapProfileDidInitializeNotification object:nil];
+}
+
+- (void)didReceiveCleverTapProfileDidInitializeNotification:(NSNotification*)notification {
+    NSString *jsonString = [self dictToJson:notification.userInfo];
+    if (jsonString != nil) {
+        [self callUnityObject:CleverTapUnityCallbackProfileInitialized withMessage:jsonString];
+    }
+}
+
+
+- (void)didReceiveCleverTapProfileDidChangeNotification:(NSNotification*)notification {
+    NSString *jsonString = [self dictToJson:notification.userInfo];
+    if (jsonString != nil) {
+        [self callUnityObject:CleverTapUnityCallbackProfileUpdates withMessage:jsonString];
+    }
+}
+
+#pragma mark - InApp Notification Delegates
+
+- (void)inAppNotificationDismissedWithExtras:(NSDictionary *)extras andActionExtras:(NSDictionary *)actionExtras {
+    
+    NSMutableDictionary *jsonDict = [NSMutableDictionary new];
+    
+    if (extras != nil) {
+        jsonDict[@"extras"] = extras;
+    }
+    
+    if (actionExtras != nil) {
+        jsonDict[@"actionExtras"] = actionExtras;
+    }
+    
+    NSString *jsonString = [self dictToJson:jsonDict];
+    
+    if (jsonString != nil) {
+        [self callUnityObject:CleverTapUnityCallbackInAppNotificationDismissed withMessage:jsonString];
+    }
+}
+
+- (void)inAppNotificationButtonTappedWithCustomExtras:(NSDictionary *)customExtras {
+    
+    NSMutableDictionary *jsonDict = [NSMutableDictionary new];
+    
+    if (customExtras != nil) {
+        jsonDict[@"customExtras"] = customExtras;
+    }
+    
+    NSString *jsonString = [self dictToJson:jsonDict];
+    
+    if (jsonString != nil) {
+        [self callUnityObject:CleverTapUnityCallbackInAppNotificationButtonTapped withMessage:jsonString];
+    }
+}
+
+
+#pragma mark - Native Display
+
+- (void)displayUnitsUpdated:(NSArray<CleverTapDisplayUnit *>*)displayUnits {
+    
+    NSMutableArray *jsonArray = [NSMutableArray new];
+    
+    for (id object in displayUnits) {
+        if ([object isKindOfClass:[CleverTapDisplayUnit class]]) {
+            CleverTapDisplayUnit *unit = object;
+            [jsonArray addObject:unit.json];
+        }
+    }
+    
+    NSMutableDictionary *jsonDict = [NSMutableDictionary new];
+    
+    if (jsonArray != nil) {
+        jsonDict[@"displayUnits"] = jsonArray;
+    }
+    
+    NSString *jsonString = [self dictToJson:jsonDict];
+    
+    if (jsonString != nil) {
+        [self callUnityObject:CleverTapUnityCallbackNativeDisplayUnitsUpdated withMessage:jsonString];
+    }
+}
+
+#pragma mark - App Inbox
+
+- (void)messageButtonTappedWithCustomExtras:(NSDictionary *)customExtras {
+    
+    NSMutableDictionary *jsonDict = [NSMutableDictionary new];
+    
+    if (customExtras != nil) {
+        jsonDict[@"customExtras"] = customExtras;
+    }
+    
+    NSString *jsonString = [self dictToJson:jsonDict];
+    
+    if (jsonString != nil) {
+        [self callUnityObject:CleverTapUnityCallbackInboxCustomExtrasButtonSelect withMessage:jsonString];
+    }
+}
+
+- (void)messageDidSelect:(CleverTapInboxMessage *_Nonnull)message atIndex:(int)index withButtonIndex:(int)buttonIndex {
+    NSMutableDictionary *body = [NSMutableDictionary new];
+    if ([message json] != nil) {
+        NSError *error;
+        if ([message json] != nil) {
+            body[@"CTInboxMessagePayload"] = [NSMutableDictionary dictionaryWithDictionary:[message json]];
+        }
+        body[@"ContentPageIndex"] = @(index);
+        body[@"ButtonIndex"] = @(buttonIndex);
+        NSString *jsonString = [self dictToJson:body];
+        if (jsonString != nil) {
+            [self callUnityObject:CleverTapUnityCallbackInboxItemClicked withMessage:jsonString];
+        }
+    }
+}
+
+#pragma mark - Push Permission Delegate
+
+- (void)onPushPermissionResponse:(BOOL)accepted {
+    NSMutableDictionary *jsonDict = [NSMutableDictionary new];
+   
+    jsonDict[@"accepted"] = [NSNumber numberWithBool:accepted];
+    
+    NSString *jsonString = [self dictToJson:jsonDict];
+
+    if (jsonString != nil) {
+        [self callUnityObject:CleverTapUnityCallbackPushPermissionResponseReceived withMessage:jsonString];
+    }
+}
+
+#pragma mark - Product Config
+
+- (void)ctProductConfigFetched {
+    [self callUnityObject:CleverTapUnityCallbackProductConfigFetched withMessage:@"Product Config Fetched"];
+}
+
+- (void)ctProductConfigActivated {
+    [self callUnityObject:CleverTapUnityCallbackProductConfigActivated withMessage:@"Product Config Activated"];
+}
+
+- (void)ctProductConfigInitialized {
+    [self callUnityObject:CleverTapUnityCallbackProductConfigInitialized withMessage:@"Product Config Initialized"];
+}
+
+#pragma mark - Feature Flags
+
+- (void)ctFeatureFlagsUpdated {
+    [self callUnityObject:CleverTapUnityCallbackFeatureFlagsUpdated withMessage:@"Feature Flags updated"];
+}
+
+@end

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.mm.meta
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.mm.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: 4be68121d6a9c4e5e917efbf5fb60000
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h
@@ -1,0 +1,55 @@
+//
+//  CleverTapUnityCallbackInfo.h
+//
+//  Created by Nikola Zagorchev on 11.11.24.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, CleverTapUnityCallback) {
+    CleverTapUnityCallbackProfileInitialized = 0,
+    CleverTapUnityCallbackProfileUpdates = 1,
+    CleverTapUnityCallbackDeepLink = 2,
+    CleverTapUnityCallbackPushOpened = 3,
+    CleverTapUnityCallbackInAppNotificationDismissed = 4,
+    CleverTapUnityCallbackInAppNotificationButtonTapped = 5,
+    CleverTapUnityCallbackOnPushPermissionResponse = 6,
+    CleverTapUnityCallbackInboxDidInitialize = 7,
+    CleverTapUnityCallbackInboxMessagesDidUpdate = 8,
+    CleverTapUnityCallbackInboxCustomExtrasButtonSelect = 9,
+    CleverTapUnityCallbackInboxItemClicked = 10,
+    CleverTapUnityCallbackInAppButtonClicked = 11,
+    CleverTapUnityCallbackNativeDisplayUnitsUpdated = 12,
+    CleverTapUnityCallbackFeatureFlagsUpdated = 13,
+    CleverTapUnityCallbackProductConfigInitialized = 14,
+    CleverTapUnityCallbackProductConfigFetched = 15,
+    CleverTapUnityCallbackProductConfigActivated = 16,
+    CleverTapUnityCallbackInitCleverTapId = 17,
+    CleverTapUnityCallbackVariablesChanged = 18,
+    CleverTapUnityCallbackVariableValueChanged = 19,
+    CleverTapUnityCallbackVariablesFetched = 20,
+    CleverTapUnityCallbackInAppsFetched = 21,
+    CleverTapUnityCallbackVariablesChangedAndNoDownloadsPending = 22,
+    CleverTapUnityCallbackVariableFileIsReady = 23,
+    CleverTapUnityCallbackCustomTemplatePresent = 24,
+    CleverTapUnityCallbackCustomFunctionPresent = 25,
+    CleverTapUnityCallbackCustomTemplateClose = 26,
+    CleverTapUnityCallbackPushReceived = 27,
+    CleverTapUnityCallbackPushPermissionResponseReceived = 28,
+    CleverTapUnityCallbackPushNotificationPermissionStatus = 29
+};
+
+@interface CleverTapUnityCallbackInfo : NSObject <NSCopying>
+
+@property (nonatomic, strong, readonly) NSString *callbackName;
+@property (nonatomic, assign, readonly) BOOL isBufferable;
+
++ (nullable CleverTapUnityCallbackInfo *)infoForCallback:(CleverTapUnityCallback)callback;
++ (nullable CleverTapUnityCallbackInfo *)callbackFromName:(NSString *)callbackName;
++ (NSArray<CleverTapUnityCallbackInfo *> *)callbackInfos;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h
@@ -1,9 +1,3 @@
-//
-//  CleverTapUnityCallbackInfo.h
-//
-//  Created by Nikola Zagorchev on 11.11.24.
-//
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -12,33 +6,30 @@ typedef NS_ENUM(NSInteger, CleverTapUnityCallback) {
     CleverTapUnityCallbackProfileInitialized = 0,
     CleverTapUnityCallbackProfileUpdates = 1,
     CleverTapUnityCallbackDeepLink = 2,
-    CleverTapUnityCallbackPushOpened = 3,
-    CleverTapUnityCallbackInAppNotificationDismissed = 4,
-    CleverTapUnityCallbackInAppNotificationButtonTapped = 5,
-    CleverTapUnityCallbackOnPushPermissionResponse = 6,
+    CleverTapUnityCallbackPushReceived = 3,
+    CleverTapUnityCallbackPushOpened = 4,
+    CleverTapUnityCallbackInAppNotificationDismissed = 5,
+    CleverTapUnityCallbackInAppNotificationButtonTapped = 6,
     CleverTapUnityCallbackInboxDidInitialize = 7,
     CleverTapUnityCallbackInboxMessagesDidUpdate = 8,
     CleverTapUnityCallbackInboxCustomExtrasButtonSelect = 9,
     CleverTapUnityCallbackInboxItemClicked = 10,
-    CleverTapUnityCallbackInAppButtonClicked = 11,
-    CleverTapUnityCallbackNativeDisplayUnitsUpdated = 12,
-    CleverTapUnityCallbackFeatureFlagsUpdated = 13,
-    CleverTapUnityCallbackProductConfigInitialized = 14,
-    CleverTapUnityCallbackProductConfigFetched = 15,
-    CleverTapUnityCallbackProductConfigActivated = 16,
-    CleverTapUnityCallbackInitCleverTapId = 17,
-    CleverTapUnityCallbackVariablesChanged = 18,
-    CleverTapUnityCallbackVariableValueChanged = 19,
-    CleverTapUnityCallbackVariablesFetched = 20,
-    CleverTapUnityCallbackInAppsFetched = 21,
-    CleverTapUnityCallbackVariablesChangedAndNoDownloadsPending = 22,
-    CleverTapUnityCallbackVariableFileIsReady = 23,
-    CleverTapUnityCallbackCustomTemplatePresent = 24,
-    CleverTapUnityCallbackCustomFunctionPresent = 25,
-    CleverTapUnityCallbackCustomTemplateClose = 26,
-    CleverTapUnityCallbackPushReceived = 27,
-    CleverTapUnityCallbackPushPermissionResponseReceived = 28,
-    CleverTapUnityCallbackPushNotificationPermissionStatus = 29
+    CleverTapUnityCallbackNativeDisplayUnitsUpdated = 11,
+    CleverTapUnityCallbackFeatureFlagsUpdated = 12,
+    CleverTapUnityCallbackProductConfigInitialized = 13,
+    CleverTapUnityCallbackProductConfigFetched = 14,
+    CleverTapUnityCallbackProductConfigActivated = 15,
+    CleverTapUnityCallbackVariablesChanged = 16,
+    CleverTapUnityCallbackVariableValueChanged = 17,
+    CleverTapUnityCallbackVariablesFetched = 18,
+    CleverTapUnityCallbackInAppsFetched = 19,
+    CleverTapUnityCallbackVariablesChangedAndNoDownloadsPending = 20,
+    CleverTapUnityCallbackVariableFileIsReady = 21,
+    CleverTapUnityCallbackCustomTemplatePresent = 22,
+    CleverTapUnityCallbackCustomFunctionPresent = 23,
+    CleverTapUnityCallbackCustomTemplateClose = 24,
+    CleverTapUnityCallbackPushPermissionResponseReceived = 25,
+    CleverTapUnityCallbackPushNotificationPermissionStatus = 26
 };
 
 @interface CleverTapUnityCallbackInfo : NSObject <NSCopying>

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h.meta
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h.meta
@@ -1,0 +1,27 @@
+fileFormatVersion: 2
+guid: 2dc236008552a4530932746394ca6da2
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
@@ -1,0 +1,90 @@
+#import "CleverTapUnityCallbackInfo.h"
+#import <Foundation/Foundation.h>
+
+@implementation CleverTapUnityCallbackInfo
+
+- (instancetype)initWithName:(NSString *)callbackName bufferable:(BOOL)bufferable {
+    self = [super init];
+    if (self) {
+        _callbackName = callbackName;
+        _isBufferable = bufferable;
+    }
+    return self;
+}
+
+- (BOOL)isEqual:(id)object {
+    if (self == object) return YES;
+    if (![object isKindOfClass:[CleverTapUnityCallbackInfo class]]) return NO;
+    
+    CleverTapUnityCallbackInfo *other = (CleverTapUnityCallbackInfo *)object;
+    return [self.callbackName isEqualToString:other.callbackName] && self.isBufferable == other.isBufferable;
+}
+
+- (NSUInteger)hash {
+    return self.callbackName.hash ^ @(self.isBufferable).hash;
+}
+
+- (id)copyWithZone:(NSZone *)zone {
+    // Return a new instance with the same property values
+    return [[CleverTapUnityCallbackInfo allocWithZone:zone] initWithName:self.callbackName bufferable:self.isBufferable];
+}
+
++ (NSArray<CleverTapUnityCallbackInfo *> *)callbackInfos {
+    static NSArray<CleverTapUnityCallbackInfo *> *callbacks = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        callbacks = @[
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileInitializedCallback" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileUpdatesCallback" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapDeepLinkCallback" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushOpenedCallback" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationDismissedCallback" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationButtonTapped" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapOnPushPermissionResponseCallback" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxDidInitializeCallback" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxMessagesDidUpdateCallback" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxCustomExtrasButtonSelect" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxItemClicked" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationButtonTapped" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapNativeDisplayUnitsUpdated" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapFeatureFlagsUpdated" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigInitialized" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigFetched" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigActivated" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInitCleverTapIdCallback" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesChanged" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariableValueChanged" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesFetched" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppsFetched" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesChangedAndNoDownloadsPending" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariableFileIsReady" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplatePresent" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomFunctionPresent" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplateClose" bufferable:NO],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushReceivedCallback" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushPermissionResponseReceived" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushNotificationPermissionStatus" bufferable:NO]
+        ];
+    });
+    return callbacks;
+}
+
++ (nullable CleverTapUnityCallbackInfo *)infoForCallback:(CleverTapUnityCallback)callback {
+    NSArray<CleverTapUnityCallbackInfo *> *callbacks = [self callbackInfos];
+    if (callback < callbacks.count) {
+        return callbacks[callback];
+    }
+    return nil;
+}
+
++ (nullable CleverTapUnityCallbackInfo *)callbackFromName:(NSString *)callbackName {
+    NSArray<CleverTapUnityCallbackInfo *> *callbacks = [self callbackInfos];
+    for (CleverTapUnityCallbackInfo *callback in callbacks) {
+        if ([callback.callbackName isEqualToString:callbackName]) {
+            return callback;
+        }
+    }
+    return nil;
+}
+
+@end

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
@@ -25,7 +25,6 @@
 }
 
 - (id)copyWithZone:(NSZone *)zone {
-    // Return a new instance with the same property values
     return [[CleverTapUnityCallbackInfo allocWithZone:zone] initWithName:self.callbackName bufferable:self.isBufferable];
 }
 
@@ -37,21 +36,19 @@
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileInitializedCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileUpdatesCallback" bufferable:NO],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapDeepLinkCallback" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushReceivedCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushOpenedCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationDismissedCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationButtonTapped" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapOnPushPermissionResponseCallback" bufferable:NO],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxDidInitializeCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxMessagesDidUpdateCallback" bufferable:NO],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxCustomExtrasButtonSelect" bufferable:NO],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxItemClicked" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationButtonTapped" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapNativeDisplayUnitsUpdated" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapFeatureFlagsUpdated" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigInitialized" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigFetched" bufferable:NO],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigActivated" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInitCleverTapIdCallback" bufferable:NO],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesChanged" bufferable:NO],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariableValueChanged" bufferable:NO],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesFetched" bufferable:NO],
@@ -61,7 +58,6 @@
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplatePresent" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomFunctionPresent" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplateClose" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushReceivedCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushPermissionResponseReceived" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushNotificationPermissionStatus" bufferable:NO]
         ];

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm.meta
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm.meta
@@ -1,0 +1,37 @@
+fileFormatVersion: 2
+guid: 05a978b5a761c4da7a92e9e0a51f5361
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      iPhone: iOS
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      tvOS: tvOS
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.h
@@ -5,13 +5,16 @@
 #import <CleverTapSDK/CleverTapUTMDetail.h>
 #import <CleverTapSDK/CleverTapEventDetail.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CleverTapUnityManager : NSObject
 
 + (CleverTapUnityManager *)sharedInstance;
 
-+ (void)launchWithAccountID:(NSString*)accountID andToken:(NSString *)token;
-+ (void)launchWithAccountID:(NSString*)accountID token:(NSString *)token region:(NSString *)region;
-+ (void)launchWithAccountID:(NSString *)accountID token:(NSString *)token proxyDomain:(NSString *)proxyDomain spikyProxyDomain:(NSString *)spikyProxyDomain;
+- (void)onCallbackAdded:(NSString *)callbackName;
+
+#pragma mark - Admin
+
 + (void)setDebugLevel:(int)level;
 + (void)enablePersonalization;
 + (void)disablePersonalization;
@@ -19,19 +22,14 @@
 + (void)registerPush;
 + (void)setApplicationIconBadgeNumber:(int)num;
 
-- (void)onCallbackAdded:(NSString *)callbackName;
-
-
 #pragma mark - Offline API
 
 - (void)setOffline:(BOOL)enabled;
-
 
 #pragma mark - Opt-out API
 
 - (void)setOptOut:(BOOL)enabled;
 - (void)enableDeviceNetworkInfoReporting:(BOOL)enabled;
-
 
 #pragma mark - User Profile
 
@@ -49,7 +47,6 @@
 - (NSString *)profileGetCleverTapID;
 - (NSString *)profileGetCleverTapAttributionIdentifier;
 
-
 #pragma mark - User Action Events
 
 - (void)recordScreenView:(NSString *)screenName;
@@ -63,7 +60,6 @@
 - (NSDictionary *)userGetEventHistory;
 - (CleverTapEventDetail *)eventGetDetail:(NSString *)event;
 
-
 #pragma mark - User Session
 
 - (NSTimeInterval)sessionGetTimeElapsed;
@@ -71,7 +67,6 @@
 - (int)userGetTotalVisits;
 - (int)userGetScreenCount;
 - (NSTimeInterval)userGetPreviousVisitTime;
-
 
 #pragma mark - Push Notifications
 
@@ -83,7 +78,6 @@
 - (void)pushInstallReferrerSource:(NSString *)source
                            medium:(NSString *)medium
                          campaign:(NSString *)campaign;
-
 
 #pragma mark - App Inbox
 
@@ -102,14 +96,12 @@
 - (void)recordInboxNotificationViewedEventForID:(NSString *)messageId;
 - (void)recordInboxNotificationClickedEventForID:(NSString *)messageId;
 
-
 #pragma mark - Native Display
 
 - (NSArray *)getAllDisplayUnits;
 - (NSDictionary *)getDisplayUnitForID:(NSString *)unitID;
 - (void)recordDisplayUnitViewedEventForID:(NSString *)unitID;
 - (void)recordDisplayUnitClickedEventForID:(NSString *)unitID;
-
 
 #pragma mark - Product Config
 
@@ -123,7 +115,6 @@
 - (NSDictionary *)getProductConfigValueFor:(NSString *)key;
 - (double)getProductConfigLastFetchTimeStamp;
 - (void)resetProductConfig;
-
 
 #pragma mark - Feature Flags
 
@@ -139,7 +130,6 @@
 - (void)promptForPushPermission:(BOOL)showFallbackSettings;
 - (void)promptPushPrimer:(NSDictionary *)json;
 - (void)isPushPermissionGranted;
-
 
 #pragma mark - Variables
 - (void)syncVariables;
@@ -182,3 +172,5 @@
 - (int8_t)customTemplateGetByteArg:(NSString *)templateName named:(NSString *)argumentName;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.h
@@ -5,8 +5,6 @@
 #import <CleverTapSDK/CleverTapUTMDetail.h>
 #import <CleverTapSDK/CleverTapEventDetail.h>
 
-static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
-
 @interface CleverTapUnityManager : NSObject
 
 + (CleverTapUnityManager *)sharedInstance;
@@ -20,6 +18,8 @@ static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
 + (void)setLocation:(CLLocationCoordinate2D)location;
 + (void)registerPush;
 + (void)setApplicationIconBadgeNumber:(int)num;
+
+- (void)onCallbackAdded:(NSString *)callbackName;
 
 
 #pragma mark - Offline API

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -40,6 +40,7 @@
         self.cleverTap = [CleverTap sharedInstance];
         NSLog(@"CleverTap default instance: %@", self.cleverTap);
         self.callbackHandler = [CleverTapUnityCallbackHandler sharedInstance];
+        [self.callbackHandler attachInstance:self.cleverTap];
         [self disableMessageBuffers];
     }
     return self;
@@ -58,26 +59,6 @@ const int PENDING_EVENTS_TIME_OUT = 5;
 }
 
 #pragma mark - Admin
-
-+ (void)launchWithAccountID:(NSString*)accountID andToken:(NSString *)token {
-    [self launchWithAccountID:accountID token:token region:nil];
-}
-
-+ (void)launchWithAccountID:(NSString *)accountID token:(NSString *)token region:(NSString *)region {
-    [CleverTap setCredentialsWithAccountID:accountID token:token region:region];
-    [self initializeAndNotifyLaunch];
-}
-
-+ (void)launchWithAccountID:(NSString *)accountID token:(NSString *)token proxyDomain:(NSString *)proxyDomain spikyProxyDomain:(NSString *)spikyProxyDomain {
-    [CleverTap setCredentialsWithAccountID:accountID token:token proxyDomain:proxyDomain spikyProxyDomain:spikyProxyDomain];
-    [self initializeAndNotifyLaunch];
-}
-
-+ (void)initializeAndNotifyLaunch {
-    // Initialize CleverTapUnityManager to register listeners and set delegates
-    [CleverTapUnityManager sharedInstance];
-    [[CleverTap sharedInstance] notifyApplicationLaunchedWithOptions:nil];
-}
 
 + (void)setApplicationIconBadgeNumber:(int)num {
     [UIApplication sharedApplication].applicationIconBadgeNumber = num;
@@ -261,6 +242,8 @@ const int PENDING_EVENTS_TIME_OUT = 5;
 + (void)registerPush {
     UIApplication *application = [UIApplication sharedApplication];
     if ([application respondsToSelector:@selector(isRegisteredForRemoteNotifications)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         UIUserNotificationSettings *settings = [UIUserNotificationSettings
                                                 settingsForTypes:UIUserNotificationTypeAlert | UIUserNotificationTypeBadge | UIUserNotificationTypeSound
                                                 categories:nil];
@@ -268,6 +251,7 @@ const int PENDING_EVENTS_TIME_OUT = 5;
         
         [application registerUserNotificationSettings:settings];
         [application registerForRemoteNotifications];
+#pragma clang diagnostic pop
     }
     else {
 #if __IPHONE_OS_VERSION_MAX_ALLOWED < 80000
@@ -355,7 +339,7 @@ const int PENDING_EVENTS_TIME_OUT = 5;
 }
 
 - (void)showAppInbox:(NSDictionary *)styleConfig {
-    CleverTapInboxViewController *inboxController = [self.cleverTap newInboxViewControllerWithConfig:[self _dictToInboxStyleConfig:styleConfig? styleConfig : nil] andDelegate:self];
+    CleverTapInboxViewController *inboxController = [self.cleverTap newInboxViewControllerWithConfig:[self _dictToInboxStyleConfig:styleConfig? styleConfig : nil] andDelegate:self.callbackHandler];
     if (inboxController) {
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:inboxController];
         [UnityGetGLViewController() presentViewController:navigationController animated:YES completion:nil];
@@ -541,6 +525,8 @@ const int PENDING_EVENTS_TIME_OUT = 5;
 
 #pragma mark - Product Config
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)fetchProductConfig {
     [[self.cleverTap productConfig] fetch];
 }
@@ -577,9 +563,9 @@ const int PENDING_EVENTS_TIME_OUT = 5;
     }
     else {
         jsonDict = @{ key: value.jsonValue };
-}
-
-return jsonDict;
+    }
+    
+    return jsonDict;
 }
 
 - (double)getProductConfigLastFetchTimeStamp {
@@ -591,13 +577,16 @@ return jsonDict;
 - (void)resetProductConfig {
     [[self.cleverTap productConfig] reset];
 }
-
+#pragma clang diagnostic pop
 
 #pragma mark - Feature Flags
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (BOOL)get:(NSString *)key withDefaultValue:(BOOL)defaultValue {
     return [[self.cleverTap featureFlags] get:key withDefaultValue:defaultValue];
 }
+#pragma clang diagnostic pop
 
 #pragma mark - Push Primer
 

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -273,10 +273,6 @@ const int PENDING_EVENTS_TIME_OUT = 5;
     [self.cleverTap handleNotificationWithData:data];
 }
 
-- (void)showInAppNotificationIfAny {
-    [self.cleverTap showInAppNotificationIfAny];
-}
-
 - (void)registerApplication:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
     [self handleNotificationWithData:notification];
     

--- a/CleverTap/Runtime/Common/CustomTemplatesFactory.cs
+++ b/CleverTap/Runtime/Common/CustomTemplatesFactory.cs
@@ -19,7 +19,7 @@ namespace CleverTapSDK.Common
 #if UNITY_ANDROID
             cleverTapCustomTemplates = new AndroidPlatformCustomTemplates();
 #elif UNITY_IOS
-            //cleverTapCustomTemplates = new IOSPlatformCustomTemplates();
+            cleverTapCustomTemplates = new IOSPlatformCustomTemplates();
 #else
             cleverTapCustomTemplates = new UnityNativePlatformCustomTemplates();
 #endif

--- a/CleverTap/Runtime/IOS/IOSCallbackHandler.cs
+++ b/CleverTap/Runtime/IOS/IOSCallbackHandler.cs
@@ -1,8 +1,14 @@
 ﻿#if UNITY_IOS
+using System;
 using CleverTapSDK.Common;
 
 namespace CleverTapSDK.IOS {
-    public class IOSCallbackHandler : CleverTapCallbackHandler {
+    public class IOSCallbackHandler : CleverTapCallbackHandler
+    {
+        internal override void OnCallbackAdded(Action<string> callbackMethod)
+        {
+            IOSDllImport.CleverTap_onCallbackAdded(callbackMethod.Method.Name);
+        }
     }
 }
 #endif

--- a/CleverTap/Runtime/IOS/IOSDllImport.cs
+++ b/CleverTap/Runtime/IOS/IOSDllImport.cs
@@ -4,8 +4,11 @@ using CleverTapSDK.IOS;
 
 namespace CleverTapSDK.IOS {
     internal static class IOSDllImport {
-        
+
         #region Bindings
+
+        [DllImport("__Internal")]
+        internal static extern void CleverTap_onCallbackAdded(string name);
 
         [DllImport("__Internal")]
         internal static extern void CleverTap_launchWithCredentials(string accountID, string token);

--- a/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
+++ b/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
@@ -2,6 +2,7 @@
 using CleverTapSDK.Common;
 using CleverTapSDK.Constants;
 using CleverTapSDK.Utilities;
+using System;
 using System.Collections.Generic;
 
 namespace CleverTapSDK.IOS {
@@ -181,18 +182,23 @@ namespace CleverTapSDK.IOS {
             return true;
         }
 
+#pragma warning disable CS0809
+        [Obsolete("This method no longer does anything. " +
+            "Replaced with initialization in the application:didFinishLaunchingWithOptions:")]
         internal override void LaunchWithCredentials(string accountID, string token) {
-            IOSDllImport.CleverTap_launchWithCredentials(accountID, token);
         }
 
+        [Obsolete("This method no longer does anything. " +
+    "Replaced with initialization in the application:didFinishLaunchingWithOptions:")]
         internal override void LaunchWithCredentialsForRegion(string accountID, string token, string region) {
-            IOSDllImport.CleverTap_launchWithCredentialsForRegion(accountID, token, region);
         }
 
+        [Obsolete("This method no longer does anything. " +
+    "Replaced with initialization in the application:didFinishLaunchingWithOptions:")]
         internal override void LaunchWithCredentialsForProxyServer(string accountID, string token, string proxyDomain, string spikyProxyDomain) {
-            IOSDllImport.CleverTap_launchWithCredentialsForProxyServer(accountID, token, proxyDomain, spikyProxyDomain);
         }
-        
+#pragma warning restore CS0809
+
         internal override void MarkReadInboxMessageForID(string messageId) {
             IOSDllImport.CleverTap_markReadInboxMessageForID(messageId);
         }


### PR DESCRIPTION
## Overview
Initialize CleverTap on `application:didFinishLaunchingWithOptions:` using a subclass of the `UnityAppController`. Buffer the callback messages until Unity initializes and listeners are added. Use the `CleverTapUnityCallbackHandler` to handle the callbacks.
