### PR TITLE
Fix Android file var value

### DIFF
--- a/CTExample/Assets/Scripts/Variables/Variables.cs
+++ b/CTExample/Assets/Scripts/Variables/Variables.cs
@@ -290,8 +290,18 @@ namespace CTExample
 
             Logger.Log($"Name: {varHello.Name}, Default Value: {varHello.DefaultValue}, Value: {varHello.Value}");
 
-            Logger.Log($"Name: {factory_var_file.Name}, Default Value: {factory_var_file.DefaultValue}, Value: {factory_var_file.Value}, File Value: {factory_var_file.FileValue}");
-            Logger.Log($"Name: {folder1FileVariable.Name}, Default Value: {folder1FileVariable.DefaultValue}, Value: {folder1FileVariable.Value}, File Value: {folder1FileVariable.FileValue}");
+            Logger.Log($"Name: {factory_var_file.Name}, File Exists: {FileExists(factory_var_file.FileValue)}, Value: {factory_var_file.Value}, File Value: {factory_var_file.FileValue}");
+            Logger.Log($"Name: {folder1FileVariable.Name}, File Exists: {FileExists(folder1FileVariable.FileValue)}, Value: {folder1FileVariable.Value}, File Value: {folder1FileVariable.FileValue}");
+        }
+
+        private static bool FileExists(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath))
+            {
+                return false;
+            }
+
+            return System.IO.File.Exists(filePath);
         }
 
         private void OnVariablesChanged()

--- a/CleverTap/Runtime/Android/AndroidVar.cs
+++ b/CleverTap/Runtime/Android/AndroidVar.cs
@@ -1,6 +1,5 @@
 ﻿#if UNITY_ANDROID
 using CleverTapSDK.Common;
-using CleverTapSDK.Constants;
 using CleverTapSDK.Utilities;
 using System;
 using System.Collections;
@@ -14,15 +13,6 @@ namespace CleverTapSDK.Android {
                 string jsonRepresentation = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getVariableValue", name);
                 if (jsonRepresentation == Json.Serialize(value)) {
                     return value;
-                }
-
-                if (kind.Equals(CleverTapVariableKind.FILE)) {
-                    if (typeof(T) == typeof(string)) {
-                        return (T)Convert.ChangeType(jsonRepresentation, typeof(T));
-                    } else {
-                        CleverTapLogger.LogError("File variables must be of string type");
-                        return value;
-                    }
                 }
 
                 object newValue = Json.Deserialize(jsonRepresentation);


### PR DESCRIPTION
## Overview
File value is received with double quotes on Android. The file cannot be found. Exception is thrown when trying to read it from Unity using sample code:

```java
DirectoryNotFoundException: Could not find a part of the path "/"/data/user/0/com.clevertap.unity.example/app_CleverTap.Files./CT_FILE_123d590f-4acf-3880-9e66-22af65ab999f"".
```

## Implementation
Remove the special handling for File variables in `CleverTap/Runtime/Android/AndroidVar.cs`. The file variable value is a string and it can be parsed without special handling. 