### PR TITLE
Change the way CleverTapInAppNotificationShowCallback is invoked

### DIFF
--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
@@ -74,9 +74,6 @@ public class CleverTapUnityPlugin implements SyncListener, InAppNotificationList
     private static final String CLEVERTAP_INAPP_NOTIFICATION_DISMISSED_CALLBACK
             = "CleverTapInAppNotificationDismissedCallback";
 
-    private static final String CLEVERTAP_INAPP_NOTIFICATION_SHOW_CALLBACK
-            = "CleverTapInAppNotificationShowCallback";
-
     private static final String CLEVERTAP_ON_PUSH_PERMISSION_RESPONSE_CALLBACK
             = "CleverTapOnPushPermissionResponseCallback";
 
@@ -117,6 +114,8 @@ public class CleverTapUnityPlugin implements SyncListener, InAppNotificationList
     private static CleverTapUnityPlugin instance = null;
 
     private CleverTapAPI clevertap = null;
+
+    private PluginCallback inAppOnShowCallback = null;
 
     private static void changeCredentials(final String accountID, final String accountToken, final String region) {
         CleverTapAPI.changeCredentials(accountID, accountToken, region);
@@ -984,16 +983,23 @@ public class CleverTapUnityPlugin implements SyncListener, InAppNotificationList
     }
 
     // InAppNotificationListener
+    public void setInAppNotificationOnShowCallback(PluginCallback callback) {
+        inAppOnShowCallback = callback;
+    }
+
     public boolean beforeShow(Map<String, Object> var1) {
         return true;
     }
 
     @SuppressLint("RestrictedApi")
     public void onShow(CTInAppNotification ctInAppNotification) {
+        final PluginCallback onShowCallback = inAppOnShowCallback;
+        if (onShowCallback == null) {
+            Log.d(LOG_TAG, "Will not trigger onShow for InApp without NotificationOnShowCallback");
+            return;
+        }
         if (ctInAppNotification != null && ctInAppNotification.getJsonDescription() != null) {
-            messageUnity(CLEVERTAP_GAME_OBJECT_NAME,
-                    CLEVERTAP_INAPP_NOTIFICATION_SHOW_CALLBACK,
-                    ctInAppNotification.getJsonDescription().toString());
+            onShowCallback.Invoke(ctInAppNotification.getJsonDescription().toString());
         } else {
             Log.e(LOG_TAG, "Could not trigger onShow for InApp with null json description");
         }

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/PluginCallback.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/PluginCallback.java
@@ -1,0 +1,5 @@
+package com.clevertap.unity;
+
+public interface PluginCallback {
+    void Invoke(String message);
+}

--- a/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
+++ b/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
@@ -6,8 +6,13 @@ using System.Collections.Generic;
 
 namespace CleverTapSDK.Android {
     internal class AndroidPlatformBinding : CleverTapPlatformBindings {
-        internal AndroidPlatformBinding() {
+        internal AndroidPlatformBinding()
+        {
             CallbackHandler = CreateGameObjectAndAttachCallbackHandler<AndroidCallbackHandler>(CleverTapGameObjectName.ANDROID_CALLBACK_HANDLER);
+            CleverTapAndroidJNI.OnInitCleverTapInstanceDelegate = cleverTapJniInstance =>
+            {
+                cleverTapJniInstance.Call("setInAppNotificationOnShowCallback", new InAppOnShowCallback(CallbackHandler));
+            };
             CleverTapLogger.Log("Start: CleverTap binding for Android.");
         }
 
@@ -286,6 +291,20 @@ namespace CleverTapSDK.Android {
         */
         internal override void ResumeInAppNotifications() {
             CleverTapAndroidJNI.CleverTapJNIInstance.Call("resumeInAppNotifications");
+        }
+
+        internal class InAppOnShowCallback : AndroidPluginCallback
+        {
+            private readonly CleverTapCallbackHandler CallbackHandler;
+            public InAppOnShowCallback(CleverTapCallbackHandler callbackHandler)
+            {
+                CallbackHandler = callbackHandler;
+            }
+
+            internal override void Invoke(string message)
+            {
+                CallbackHandler.CleverTapInAppNotificationShowCallback(message);
+            }
         }
 
         internal override int SessionGetTimeElapsed() {

--- a/CleverTap/Runtime/Android/AndroidPluginCallback.cs
+++ b/CleverTap/Runtime/Android/AndroidPluginCallback.cs
@@ -1,0 +1,10 @@
+#if UNITY_ANDROID
+namespace CleverTapSDK.Android {
+    internal abstract class AndroidPluginCallback : UnityEngine.AndroidJavaProxy {
+
+        internal AndroidPluginCallback(): base("com.clevertap.unity.PluginCallback") {}
+
+        internal abstract void Invoke(string message);
+    }
+}
+#endif

--- a/CleverTap/Runtime/Android/AndroidPluginCallback.cs.meta
+++ b/CleverTap/Runtime/Android/AndroidPluginCallback.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a40aa21f088b4d70abd10ae7e8b0fb1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Runtime/Android/CleverTapAndroidJNI.cs
+++ b/CleverTap/Runtime/Android/CleverTapAndroidJNI.cs
@@ -13,6 +13,9 @@ namespace CleverTapSDK.Android {
         private static AndroidJavaObject _cleverTapJNI;
         private static AndroidJavaObject _cleverTapClass;
 
+        internal delegate void OnInitCleverTapJNI(AndroidJavaObject cleverTapInstance);
+        internal static OnInitCleverTapJNI OnInitCleverTapInstanceDelegate;
+
         internal static AndroidJavaObject UnityActivity {
             get {
                 if (_unityActivity == null) {
@@ -40,6 +43,7 @@ namespace CleverTapSDK.Android {
             get {
                 if (_cleverTapJNI == null) {
                     _cleverTapJNI = CleverTapJNIStatic.CallStatic<AndroidJavaObject>(GET_INSTANCE_METHOD, ApplicationContext);
+                    OnInitCleverTapInstanceDelegate?.Invoke(_cleverTapJNI);
                 }
                 return _cleverTapJNI;
             }


### PR DESCRIPTION
Use AndroidJavaProxy instead of UnityPlayer.sendMessage to invoke the CleverTapInAppNotificationShowCallback. This enables the callback to be received even when the UnityPlayer is paused, which is the case when an InApp is being displayed.