### PR TITLE
Custom templates merge plugin callback

### DIFF
--- a/CTExample/Assets/Scripts/App.cs
+++ b/CTExample/Assets/Scripts/App.cs
@@ -38,8 +38,11 @@ namespace CTExample
             Logger.Log($"Launching \"{accountName}\" with accountId: {accountId}, accountToken: {accountToken}, accountRegion: {accountRegion}.");
 
             // add listeners for events that may be triggered on app launch so they can be logged
-            CleverTap.OnCleverTapPushOpenedCallback += CleverTapPushOpenedCallback;
-            CleverTap.OnCleverTapDeepLinkCallback += CleverTapDeepLinkCallback;
+            CleverTap.OnCleverTapPushOpenedCallback += CleverTapCallback;
+            CleverTap.OnCleverTapDeepLinkCallback += CleverTapCallback;
+            CleverTap.OnCleverTapInAppNotificationShowCallback += CleverTapCallback;
+            CleverTap.OnCleverTapInAppNotificationButtonTapped += CleverTapCallback;
+            CleverTap.OnCleverTapInAppNotificationDismissedCallback += CleverTapCallback;
 
             // todo: add UI for custom templates
             CleverTap.OnCustomTemplatePresent += CleverTapCustomTemplatePresent;
@@ -54,11 +57,7 @@ namespace CTExample
 #endif
         }
 
-        private void CleverTapPushOpenedCallback(string message)
-        {
-        }
-
-        private void CleverTapDeepLinkCallback(string message)
+        private void CleverTapCallback(string message)
         {
         }
 

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapMessageSender.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapMessageSender.java
@@ -123,12 +123,25 @@ public class CleverTapMessageSender {
         }
 
         messageBuffer.add(messageData);
-        Log.i(LOG_TAG, "Buffering message " + callback.callbackName + ":" + messageData);
+        Log.i(LOG_TAG, "Message buffered " + callback.callbackName + ":" + messageData);
     }
 
     private void sendMessage(@NonNull CleverTapUnityCallback callback, @NonNull String data) {
-        UnityPlayer.UnitySendMessage(CLEVERTAP_GAME_OBJECT_NAME, callback.callbackName, data);
-        Log.i(LOG_TAG, "Sending message " + callback.callbackName + ":" + data);
+        switch (callback.mode) {
+            case UNITY_PLAYER_MESSAGE: {
+                UnityPlayer.UnitySendMessage(CLEVERTAP_GAME_OBJECT_NAME, callback.callbackName, data);
+                break;
+            }
+            case DIRECT_CALLBACK: {
+                if (callback.pluginCallback == null) {
+                    Log.d(LOG_TAG, "Message not sent, direct callback is null for " + callback.callbackName + ":" + data);
+                    return;
+                }
+                callback.pluginCallback.Invoke(data);
+                break;
+            }
+        }
+        Log.i(LOG_TAG, "Message sent " + callback.callbackName + ":" + data);
     }
 
     private Map<CleverTapUnityCallback, MessageBuffer> createBuffersMap(boolean enableBuffers) {

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityCallback.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityCallback.java
@@ -1,5 +1,6 @@
 package com.clevertap.unity;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 public enum CleverTapUnityCallback {
@@ -8,7 +9,7 @@ public enum CleverTapUnityCallback {
     CLEVERTAP_DEEP_LINK_CALLBACK("CleverTapDeepLinkCallback", true),
     CLEVERTAP_PUSH_OPENED_CALLBACK("CleverTapPushOpenedCallback", true),
     CLEVERTAP_INAPP_NOTIFICATION_DISMISSED_CALLBACK("CleverTapInAppNotificationDismissedCallback", true),
-    CLEVERTAP_INAPP_NOTIFICATION_SHOW_CALLBACK("CleverTapInAppNotificationShowCallback", true),
+    CLEVERTAP_INAPP_NOTIFICATION_SHOW_CALLBACK("CleverTapInAppNotificationShowCallback", true, Mode.DIRECT_CALLBACK),
     CLEVERTAP_ON_PUSH_PERMISSION_RESPONSE_CALLBACK("CleverTapOnPushPermissionResponseCallback"),
     CLEVERTAP_INBOX_DID_INITIALIZE("CleverTapInboxDidInitializeCallback", true),
     CLEVERTAP_INBOX_MESSAGES_DID_UPDATE("CleverTapInboxMessagesDidUpdateCallback"),
@@ -21,7 +22,7 @@ public enum CleverTapUnityCallback {
     CLEVERTAP_PRODUCT_CONFIG_FETCHED("CleverTapProductConfigFetched"),
     CLEVERTAP_PRODUCT_CONFIG_ACTIVATED("CleverTapProductConfigActivated"),
     CLEVERTAP_INIT_CLEVERTAP_ID_CALLBACK("CleverTapInitCleverTapIdCallback"),
-    CLEVERTAP_VARIABLES_CHANGED("CleverTapVariablesChanged"),
+    CLEVERTAP_VARIABLES_CHANGED("CleverTapVariablesChanged", true),
     CLEVERTAP_VARIABLE_VALUE_CHANGED("CleverTapVariableValueChanged"),
     CLEVERTAP_VARIABLES_FETCHED("CleverTapVariablesFetched"),
     CLEVERTAP_INAPPS_FETCHED("CleverTapInAppsFetched"),
@@ -42,15 +43,30 @@ public enum CleverTapUnityCallback {
         return null;
     }
 
+    @NonNull
     public final String callbackName;
     public final boolean bufferable;
+    @NonNull
+    public final Mode mode;
+    @Nullable
+    public PluginCallback pluginCallback;
 
-    CleverTapUnityCallback(String callbackName, boolean bufferable) {
+    CleverTapUnityCallback(@NonNull String callbackName, boolean bufferable, @NonNull Mode mode) {
         this.callbackName = callbackName;
         this.bufferable = bufferable;
+        this.mode = mode;
+    }
+
+    CleverTapUnityCallback(String callbackName, boolean bufferable) {
+        this(callbackName, bufferable, Mode.UNITY_PLAYER_MESSAGE);
     }
 
     CleverTapUnityCallback(String callbackName) {
         this(callbackName, false);
+    }
+
+    public enum Mode {
+        UNITY_PLAYER_MESSAGE,
+        DIRECT_CALLBACK
     }
 }

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
@@ -625,6 +625,10 @@ public class CleverTapUnityPlugin {
         clevertap.clearInAppResources(expiredOnly);
     }
 
+    public void setInAppNotificationOnShowCallback(PluginCallback callback) {
+        CleverTapUnityCallback.CLEVERTAP_INAPP_NOTIFICATION_SHOW_CALLBACK.pluginCallback = callback;
+    }
+
     public void customTemplateSetDismissed(String templateName) {
         CustomTemplateContext templateContext = clevertap.getActiveContextForTemplate(templateName);
         if (templateContext != null) {

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/PluginCallback.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/PluginCallback.java
@@ -1,0 +1,5 @@
+package com.clevertap.unity;
+
+public interface PluginCallback {
+    void Invoke(String message);
+}

--- a/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
+++ b/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
@@ -7,8 +7,13 @@ using System.Collections.Generic;
 
 namespace CleverTapSDK.Android {
     internal class AndroidPlatformBinding : CleverTapPlatformBindings {
-        internal AndroidPlatformBinding() {
+        internal AndroidPlatformBinding()
+        {
             CallbackHandler = CreateGameObjectAndAttachCallbackHandler<AndroidCallbackHandler>(CleverTapGameObjectName.ANDROID_CALLBACK_HANDLER);
+            CleverTapAndroidJNI.OnInitCleverTapInstanceDelegate = cleverTapJniInstance =>
+            {
+                cleverTapJniInstance.Call("setInAppNotificationOnShowCallback", new InAppOnShowCallback(CallbackHandler));
+            };
             CleverTapLogger.Log("Start: CleverTap binding for Android.");
         }
 
@@ -290,6 +295,20 @@ namespace CleverTapSDK.Android {
         */
         internal override void ResumeInAppNotifications() {
             CleverTapAndroidJNI.CleverTapJNIInstance.Call("resumeInAppNotifications");
+        }
+
+        internal class InAppOnShowCallback : AndroidPluginCallback
+        {
+            private readonly CleverTapCallbackHandler CallbackHandler;
+            public InAppOnShowCallback(CleverTapCallbackHandler callbackHandler)
+            {
+                CallbackHandler = callbackHandler;
+            }
+
+            internal override void Invoke(string message)
+            {
+                CallbackHandler.CleverTapInAppNotificationShowCallback(message);
+            }
         }
 
         internal override int SessionGetTimeElapsed() {

--- a/CleverTap/Runtime/Android/AndroidPluginCallback.cs
+++ b/CleverTap/Runtime/Android/AndroidPluginCallback.cs
@@ -1,0 +1,10 @@
+#if UNITY_ANDROID
+namespace CleverTapSDK.Android {
+    internal abstract class AndroidPluginCallback : UnityEngine.AndroidJavaProxy {
+
+        internal AndroidPluginCallback(): base("com.clevertap.unity.PluginCallback") {}
+
+        internal abstract void Invoke(string message);
+    }
+}
+#endif

--- a/CleverTap/Runtime/Android/AndroidPluginCallback.cs.meta
+++ b/CleverTap/Runtime/Android/AndroidPluginCallback.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a40aa21f088b4d70abd10ae7e8b0fb1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Runtime/Android/CleverTapAndroidJNI.cs
+++ b/CleverTap/Runtime/Android/CleverTapAndroidJNI.cs
@@ -13,6 +13,9 @@ namespace CleverTapSDK.Android {
         private static AndroidJavaObject _cleverTapJNI;
         private static AndroidJavaObject _cleverTapClass;
 
+        internal delegate void OnInitCleverTapJNI(AndroidJavaObject cleverTapInstance);
+        internal static OnInitCleverTapJNI OnInitCleverTapInstanceDelegate;
+
         internal static AndroidJavaObject UnityActivity {
             get {
                 if (_unityActivity == null) {
@@ -40,6 +43,7 @@ namespace CleverTapSDK.Android {
             get {
                 if (_cleverTapJNI == null) {
                     _cleverTapJNI = CleverTapJNIStatic.CallStatic<AndroidJavaObject>(GET_INSTANCE_METHOD, ApplicationContext);
+                    OnInitCleverTapInstanceDelegate?.Invoke(_cleverTapJNI);
                 }
                 return _cleverTapJNI;
             }


### PR DESCRIPTION
Make the PluginCallback work with CleverTapMessageSender.

Note that for InApps triggered on App Launched the InApp callbacks are all triggered at once (onShow, onButtonTapped and onDismiss). This is due to the InApp activity launching before the Unity libraries have loaded and they load only after the InApp is dismissed. This causes the events to be buffered and only develired after the InApp is closed.

Another thing to note is that with the current implementation of the callback buffering, the buffered callbacks are delivered in the order in which the client's delegates are attached to the CleverTap C# API. So in this example:

`
CleverTap.OnCleverTapInAppNotificationDismissedCallback += CleverTapCallback;
CleverTap.OnCleverTapInAppNotificationButtonTapped += CleverTapCallback;
CleverTap.OnCleverTapInAppNotificationShowCallback += CleverTapCallback;
` 
and in the case where the InApp is on App Launched and it is closed by a button click: The callbacks will be triggered in this confusing order:
Dismissed, ButtonTapped, Show 