### PR TITLE
Custom Templates iOS Export

### DIFF
--- a/CleverTap/Editor/AndroidPostBuildProcessor.cs
+++ b/CleverTap/Editor/AndroidPostBuildProcessor.cs
@@ -1,0 +1,115 @@
+﻿#if (UNITY_IOS || UNITY_ANDROID) && UNITY_EDITOR
+using System.IO;
+using System.Xml;
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEngine;
+
+namespace CleverTapSDK.Private
+{
+    public class AndroidPostBuildProcessor
+	{
+        private static readonly string ANDROID_XML_NS_URI = "http://schemas.android.com/apk/res/android";
+
+        [PostProcessBuild(99)]
+        public void OnPostprocessBuild(BuildTarget target, string path)
+        {
+            if (target == BuildTarget.Android)
+            {
+                AndroidPostProcess(path);
+            }
+        }
+
+        private static void AndroidPostProcess(string path)
+        {
+            string androidProjectPath = path + "/unityLibrary/clevertap-android-wrapper.androidlib";
+
+            // copy assets to the android project
+            EditorUtils.DirectoryCopy(Path.Combine(Application.dataPath, "/CleverTap"),
+                Path.Combine(androidProjectPath, "/assets/CleverTap"));
+            // copy CleverTapSettings to the project's AndroidManifest
+            CopySettingsToAndroidManifest(androidProjectPath);
+        }
+
+        private static void CopySettingsToAndroidManifest(string androidProjectPath)
+        {
+            var settings = AssetDatabase.LoadAssetAtPath<CleverTapSettings>(CleverTapSettings.settingsPath);
+            if (settings == null)
+            {
+                Debug.Log($"CleverTapSettings have not been set.\n" +
+                $"Please update them from {CleverTapSettingsWindow.ITEM_NAME} or " +
+                $"set them manually in the project's AndroidManifest.xml.");
+                return;
+            }
+
+            string manifestFilePath = androidProjectPath + "/src/main/AndroidManifest.xml";
+            var manifestXml = new XmlDocument();
+            manifestXml.Load(manifestFilePath);
+            var manifestNode = manifestXml.SelectSingleNode("/manifest");
+            if (manifestNode == null)
+            {
+                Debug.LogError("Failed to find manifest node in AndroidManifest.xml");
+                return;
+            }
+            if (manifestNode.Attributes["xmlns:android"] == null)
+            {
+                var nsAttribute = manifestXml.CreateAttribute("xmlns:android");
+                nsAttribute.Value = ANDROID_XML_NS_URI;
+                manifestNode.Attributes.Append(nsAttribute);
+            }
+
+            var namespaceManager = new XmlNamespaceManager(manifestXml.NameTable);
+            if (!namespaceManager.HasNamespace("android"))
+            {
+                if (manifestNode.Attributes["xmlns:android"] == null)
+                {
+                    var nsAttribute = manifestXml.CreateAttribute("xmlns:android");
+                    nsAttribute.Value = ANDROID_XML_NS_URI;
+                    manifestNode.Attributes.Append(nsAttribute);
+                }
+                namespaceManager.AddNamespace("android", ANDROID_XML_NS_URI);
+            }
+            var applicationNode = manifestXml.SelectSingleNode("/manifest/application");
+            if (applicationNode == null)
+            {
+                applicationNode = manifestXml.CreateElement("application");
+                manifestNode.AppendChild(applicationNode);
+            }
+
+            UpdateMetaDataNode(manifestXml, applicationNode, namespaceManager, "CLEVERTAP_ACCOUNT_ID", settings.CleverTapAccountId);
+            UpdateMetaDataNode(manifestXml, applicationNode, namespaceManager, "CLEVERTAP_TOKEN", settings.CleverTapAccountToken);
+            UpdateMetaDataNode(manifestXml, applicationNode, namespaceManager, "CLEVERTAP_REGION", settings.CleverTapAccountRegion);
+            UpdateMetaDataNode(manifestXml, applicationNode, namespaceManager, "CLEVERTAP_PROXY_DOMAIN", settings.CleverTapProxyDomain);
+            UpdateMetaDataNode(manifestXml, applicationNode, namespaceManager, "CLEVERTAP_SPIKY_PROXY_DOMAIN", settings.CleverTapSpikyProxyDomain);
+
+            manifestXml.Save(manifestFilePath);
+        }
+
+        private static void UpdateMetaDataNode(XmlDocument manifestXml, XmlNode applicationNode, XmlNamespaceManager nsManager, string name, string value)
+        {
+            var hasNewValue = !string.IsNullOrWhiteSpace(value);
+            var existingNode = applicationNode.SelectSingleNode($"meta-data[@android:name='{name}']", nsManager);
+            if (existingNode != null)
+            {
+                if (hasNewValue)
+                {
+                    existingNode.Attributes["android:value"].Value = value;
+                }
+                else
+                {
+                    applicationNode.RemoveChild(existingNode);
+                }
+                return;
+            }
+
+            if (hasNewValue)
+            {
+                var newElement = manifestXml.CreateElement("meta-data");
+                newElement.SetAttribute("name", ANDROID_XML_NS_URI, name);
+                newElement.SetAttribute("value", ANDROID_XML_NS_URI, value);
+                applicationNode.AppendChild(newElement);
+            }
+        }
+    }
+}
+#endif

--- a/CleverTap/Editor/AndroidPostBuildProcessor.cs
+++ b/CleverTap/Editor/AndroidPostBuildProcessor.cs
@@ -1,4 +1,4 @@
-﻿#if (UNITY_IOS || UNITY_ANDROID) && UNITY_EDITOR
+﻿#if UNITY_ANDROID && UNITY_EDITOR
 using System.IO;
 using System.Xml;
 using UnityEditor;
@@ -12,7 +12,7 @@ namespace CleverTapSDK.Private
         private static readonly string ANDROID_XML_NS_URI = "http://schemas.android.com/apk/res/android";
 
         [PostProcessBuild(99)]
-        public void OnPostprocessBuild(BuildTarget target, string path)
+        public static void OnPostprocessBuild(BuildTarget target, string path)
         {
             if (target == BuildTarget.Android)
             {
@@ -25,8 +25,8 @@ namespace CleverTapSDK.Private
             string androidProjectPath = path + "/unityLibrary/clevertap-android-wrapper.androidlib";
 
             // copy assets to the android project
-            EditorUtils.DirectoryCopy(Path.Combine(Application.dataPath, "/CleverTap"),
-                Path.Combine(androidProjectPath, "/assets/CleverTap"));
+            EditorUtils.DirectoryCopy(Path.Combine(Application.dataPath, EditorUtils.CLEVERTAP_ASSETS_FOLDER),
+                Path.Combine(androidProjectPath, $"assets/{EditorUtils.CLEVERTAP_APP_ASSETS_FOLDER}"));
             // copy CleverTapSettings to the project's AndroidManifest
             CopySettingsToAndroidManifest(androidProjectPath);
         }
@@ -61,12 +61,6 @@ namespace CleverTapSDK.Private
             var namespaceManager = new XmlNamespaceManager(manifestXml.NameTable);
             if (!namespaceManager.HasNamespace("android"))
             {
-                if (manifestNode.Attributes["xmlns:android"] == null)
-                {
-                    var nsAttribute = manifestXml.CreateAttribute("xmlns:android");
-                    nsAttribute.Value = ANDROID_XML_NS_URI;
-                    manifestNode.Attributes.Append(nsAttribute);
-                }
                 namespaceManager.AddNamespace("android", ANDROID_XML_NS_URI);
             }
             var applicationNode = manifestXml.SelectSingleNode("/manifest/application");

--- a/CleverTap/Editor/AndroidPostBuildProcessor.cs.meta
+++ b/CleverTap/Editor/AndroidPostBuildProcessor.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: ff52f779506f24e2f8280953896f4635
+guid: 07c93233c64ca40879b99568f4d862f0
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/CleverTap/Editor/EditorUtils.cs
+++ b/CleverTap/Editor/EditorUtils.cs
@@ -1,0 +1,53 @@
+﻿using System.IO;
+
+namespace CleverTapSDK.Private
+{
+	public static class EditorUtils
+	{
+        public static void DirectoryCopy(string sourceDirName, string destDirName, bool copyChangedOnly = true, bool copySubDirs = true)
+        {
+            DirectoryInfo dir = new DirectoryInfo(sourceDirName);
+            if (!dir.Exists)
+            {
+                throw new DirectoryNotFoundException("Source directory does not exist or could not be found: " + sourceDirName);
+            }
+
+            DirectoryInfo[] dirs = dir.GetDirectories();
+            Directory.CreateDirectory(destDirName);
+
+            FileInfo[] files = dir.GetFiles();
+            foreach (FileInfo file in files)
+            {
+                if (file.Extension == ".meta")
+                    continue;
+
+                string destPath = Path.Combine(destDirName, file.Name);
+                if (copyChangedOnly)
+                {
+                    bool overwrite = false;
+                    bool exists = File.Exists(destPath);
+                    if (exists)
+                    {
+                        overwrite = File.GetLastWriteTime(destPath) > File.GetLastWriteTime(destPath);
+                    }
+
+                    if (!exists || overwrite)
+                        file.CopyTo(destPath, overwrite);
+                }
+                else
+                {
+                    file.CopyTo(destPath, true);
+                }
+            }
+
+            if (copySubDirs)
+            {
+                foreach (DirectoryInfo subdir in dirs)
+                {
+                    string tempPath = Path.Combine(destDirName, subdir.Name);
+                    DirectoryCopy(subdir.FullName, tempPath, copySubDirs);
+                }
+            }
+        }
+    }
+}

--- a/CleverTap/Editor/EditorUtils.cs
+++ b/CleverTap/Editor/EditorUtils.cs
@@ -4,6 +4,8 @@ namespace CleverTapSDK.Private
 {
 	public static class EditorUtils
 	{
+        public static readonly string CLEVERTAP_ASSETS_FOLDER = "CleverTap";
+		public static readonly string CLEVERTAP_APP_ASSETS_FOLDER = "CleverTapSDK";
         public static void DirectoryCopy(string sourceDirName, string destDirName, bool copyChangedOnly = true, bool copySubDirs = true)
         {
             DirectoryInfo dir = new DirectoryInfo(sourceDirName);

--- a/CleverTap/Editor/EditorUtils.cs.meta
+++ b/CleverTap/Editor/EditorUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ba08de640b2d49aea124a7ae319ec57
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Editor/IOSPostBuildProcessor.cs
+++ b/CleverTap/Editor/IOSPostBuildProcessor.cs
@@ -1,4 +1,4 @@
-﻿#if (UNITY_IOS || UNITY_ANDROID) && UNITY_EDITOR
+﻿#if UNITY_IOS && UNITY_EDITOR
 using System.Collections.Generic;
 using System.IO;
 using UnityEditor;
@@ -147,15 +147,13 @@ namespace CleverTapSDK.Private
         private static void AddCleverTapFolder(string path, PBXProject proj)
         {
 			// Copy CleverTap folder
-			string cleverTapAssetsFolder = "CleverTap";
-			string cleverTapIOSBuildFolder = "CleverTapSDK";
-            string sourceFolderPath = Path.Combine(Application.dataPath, cleverTapAssetsFolder);
-            string destinationFolderPath = Path.Combine(path, cleverTapIOSBuildFolder);
+            string sourceFolderPath = Path.Combine(Application.dataPath, EditorUtils.CLEVERTAP_ASSETS_FOLDER);
+            string destinationFolderPath = Path.Combine(path, EditorUtils.CLEVERTAP_APP_ASSETS_FOLDER);
             EditorUtils.DirectoryCopy(sourceFolderPath, destinationFolderPath);
 
             string mainTargetGuid = proj.GetUnityMainTargetGuid();
             // Add CleverTap folder reference and target membership
-            string folderGuid = proj.AddFolderReference(destinationFolderPath, cleverTapIOSBuildFolder);
+            string folderGuid = proj.AddFolderReference(destinationFolderPath, EditorUtils.CLEVERTAP_APP_ASSETS_FOLDER);
             proj.AddFileToBuild(mainTargetGuid, folderGuid);
         }
 

--- a/CleverTap/Editor/IOSPostBuildProcessor.cs.meta
+++ b/CleverTap/Editor/IOSPostBuildProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8aae643cb09d1464e96b485c2592cf20
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapCustomTemplates.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapCustomTemplates.java
@@ -20,7 +20,7 @@ import java.nio.charset.StandardCharsets;
 
 public class CleverTapCustomTemplates {
 
-    private static final String TEMPLATES_DEFINITIONS_ASSETS_FOLDER = "CleverTap/CustomTemplates";
+    private static final String TEMPLATES_DEFINITIONS_ASSETS_FOLDER = "CleverTapSDK/CustomTemplates";
 
     public static void registerCustomTemplates(Context context) {
         try {

--- a/CleverTap/Plugins/iOS/CleverTapCustomTemplates.h
+++ b/CleverTap/Plugins/iOS/CleverTapCustomTemplates.h
@@ -2,33 +2,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+static NSString * kCleverTapDirName = @"CleverTapSDK";
+static NSString * kCustomTemplatesDirName = @"CustomTemplates";
+
 /// Registers Custom Templates and App Functions using JSON templates definitions.
 @interface CleverTapCustomTemplates : NSObject
 
-/// Registers Custom Templates and App Functions given JSON templates definition file names.
-/// Provide the file name only, without the json extension.
-/// Uses the main bundle to get the file path. Ensure the files are aded to the Copy Bundle Resources phase.
-/// Supports multiple file names with a nil termination.
-///
-/// Example registering Custom Templates and App Functions using JSON templates definition.
-/// The JSON file name is "templates.json".
-/// ```
-/// [CleverTapReactCustomTemplates registerCustomTemplates:@"templates", nil];
-/// ```
-///
-/// @param firstJsonAsset The first JSON templates definition file name.
-/// @param ... A comma-separated list of additional file names, ending with nil.
-+ (void)registerCustomTemplates:(NSString *)firstJsonAsset, ... NS_REQUIRES_NIL_TERMINATION;
-
-/// Registers Custom Templates and App Functions given JSON templates definition file names.
-/// Use the bundle where the resources are.
-/// Provide the file name only, without the json extension.
-/// Supports multiple file names with a nil termination.
-///
-/// @param bundle The bundle where the JSON resources are.
-/// @param firstJsonAsset The first JSON templates definition file name.
-/// @param ... A comma-separated list of additional file names, ending with nil.
-+ (void)registerCustomTemplates:(NSBundle *)bundle jsonFileNames:(NSString *)firstJsonAsset, ... NS_REQUIRES_NIL_TERMINATION;
+/// Registers Custom Templates and App Functions using the JSON templates definition files.
+/// Uses the files located in `CleverTapSDK/CustomTemplates` folder in the main bundle.
+/// Ensure the folder is aded to the Copy Bundle Resources phase.
++ (void)registerCustomTemplates;
 
 @end
 

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
@@ -1,11 +1,12 @@
 #import "CleverTapUnityAppController.h"
 #import "CleverTapUnityManager.h"
+#import "CleverTapCustomTemplates.h"
 #import <CleverTapSDK/CleverTap.h>
 
 @implementation CleverTapUnityAppController
 
-- (BOOL)application:(UIApplication*)application didFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
-    
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    [CleverTapCustomTemplates registerCustomTemplates];
     [CleverTap autoIntegrate];
     [CleverTapUnityManager sharedInstance];
     return [super application:application didFinishLaunchingWithOptions:launchOptions];


### PR DESCRIPTION
## Overview
Process iOS build. 
Copy the `Assets/CleverTap` folder and add it to the `Copy Bundle Resources` Build Phase. The template definition JSON files must be in `Assets/CleverTap/CustomTemplates` folder. 
Register the custom templates.

## Implementation
Refactor the `CleverTapPostBuildProcessor` into `AndroidPostBuildProcessor` and `IOSPostBuildProcessor`.
Extract method for copying files and directories into `EditorUtils` so it can be used by the build processors.
Reference the folder into the `Copy Bundle Resources` and add Target Membership.