### PR TITLE
iOS Push Permission callbacks fix

### DIFF
--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.mm
@@ -257,21 +257,13 @@
 #pragma mark - Push Permissions
 
 - (void)pushPermissionCallback:(BOOL)isPushEnabled {
-    [self callUnityObject:CleverTapUnityCallbackPushNotificationPermissionStatus withMessage:[NSString stringWithFormat:@"%@", isPushEnabled? @"True": @"False"]];
+    [self callUnityObject:CleverTapUnityCallbackPushNotificationPermissionStatus withMessage:[NSString stringWithFormat:@"%@", isPushEnabled ? @"True": @"False"]];
 }
 
 #pragma mark - Push Permission Delegate
 
 - (void)onPushPermissionResponse:(BOOL)accepted {
-    NSMutableDictionary *jsonDict = [NSMutableDictionary new];
-   
-    jsonDict[@"accepted"] = [NSNumber numberWithBool:accepted];
-    
-    NSString *jsonString = [self dictToJson:jsonDict];
-
-    if (jsonString != nil) {
-        [self callUnityObject:CleverTapUnityCallbackPushPermissionResponseReceived withMessage:jsonString];
-    }
+    [self callUnityObject:CleverTapUnityCallbackPushPermissionResponseReceived withMessage:[NSString stringWithFormat:@"%@", accepted ? @"True": @"False"]];
 }
 
 #pragma mark - Product Config

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
@@ -58,7 +58,7 @@
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplatePresent" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomFunctionPresent" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplateClose" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushPermissionResponseReceived" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapOnPushPermissionResponseCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushNotificationPermissionStatus" bufferable:NO]
         ];
     });

--- a/CleverTap/Runtime/CleverTap.cs
+++ b/CleverTap/Runtime/CleverTap.cs
@@ -68,6 +68,12 @@ namespace CleverTapSDK {
             remove => cleverTapCallbackHandler.OnCleverTapOnPushPermissionResponseCallback -= value;
         }
 
+        public static event CleverTapCallbackWithMessageDelegate OnCleverTapPushNotificationPermissionStatusCallback
+        {
+            add => cleverTapCallbackHandler.OnCleverTapPushNotificationPermissionStatusCallback += value;
+            remove => cleverTapCallbackHandler.OnCleverTapPushNotificationPermissionStatusCallback -= value;
+        }
+
         public static event CleverTapCallbackWithMessageDelegate OnCleverTapInAppNotificationButtonTapped {
             add => cleverTapCallbackHandler.OnCleverTapInAppNotificationButtonTapped += value;
             remove => cleverTapCallbackHandler.OnCleverTapInAppNotificationButtonTapped -= value;

--- a/CleverTap/Runtime/Common/CleverTapCallbackHandler.cs
+++ b/CleverTap/Runtime/Common/CleverTapCallbackHandler.cs
@@ -171,6 +171,26 @@ namespace CleverTapSDK.Common {
             }
         }
 
+        private CleverTapCallbackWithMessageDelegate _OnCleverTapPushNotificationPermissionStatusCallback;
+        public event CleverTapCallbackWithMessageDelegate OnCleverTapPushNotificationPermissionStatusCallback
+        {
+            add
+            {
+                lock (CallbackLock)
+                {
+                    _OnCleverTapPushNotificationPermissionStatusCallback += value;
+                    OnCallbackAdded(CleverTapPushNotificationPermissionStatus);
+                }
+            }
+            remove
+            {
+                lock (CallbackLock)
+                {
+                    _OnCleverTapPushNotificationPermissionStatusCallback -= value;
+                }
+            }
+        }
+
         private CleverTapCallbackWithMessageDelegate _OnCleverTapInAppNotificationButtonTapped;
         public event CleverTapCallbackWithMessageDelegate OnCleverTapInAppNotificationButtonTapped
         {
@@ -568,11 +588,24 @@ namespace CleverTapSDK.Common {
             _OnCleverTapInAppNotificationShowCallback?.Invoke(message);
         }
 
-        // returns the status of push permission response after it's granted/denied
+        /// <summary>
+        /// Returns the status of push permission response after it's granted/denied
+        /// </summary>
+        /// <param name="message">String boolean if permission is accepted.</param>
         public virtual void CleverTapOnPushPermissionResponseCallback(string message) {
-            //Ensure to create call the `CreateNotificationChannel` once notification permission is granted to register for receiving push notifications for Android 13+ devices.
-            CleverTapLogger.Log("unity received push permission response: " + (!String.IsNullOrEmpty(message) ? message : "NULL"));
+            // Ensure to create call the `CreateNotificationChannel` once notification permission is granted to register for receiving push notifications for Android 13+ devices.
+            CleverTapLogger.Log("unity received push permission response: " + (!string.IsNullOrEmpty(message) ? message : "NULL"));
             _OnCleverTapOnPushPermissionResponseCallback?.Invoke(message);
+        }
+
+        /// <summary>
+        /// IOS Only callback. Use when checking if push permission is granted.
+        /// </summary>
+        /// <param name="message">String boolean if status is enabled.</param>
+        public virtual void CleverTapPushNotificationPermissionStatus(string message)
+        {
+            CleverTapLogger.Log("unity received push status response: " + (!string.IsNullOrEmpty(message) ? message : "NULL"));
+            _OnCleverTapPushNotificationPermissionStatusCallback?.Invoke(message);
         }
 
         // returns when an in-app notification is dismissed by a call to action with custom extras

--- a/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
+++ b/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
@@ -176,10 +176,17 @@ namespace CleverTapSDK.IOS {
             IOSDllImport.CleverTap_initializeInbox();
         }
 
+        /// <summary>
+        /// Checks if push permission is granted.
+        /// Use the <see cref="OnCleverTapPushNotificationPermissionStatusCallback"/> to get the result.
+        /// </summary>
+        /// <returns>
+        /// Do not use the returned result. Returns false.
+        /// Use the permission status callback for result.
+        /// </returns>
         internal override bool IsPushPermissionGranted() {
             IOSDllImport.CleverTap_isPushPermissionGranted();
-            // Added for iOS
-            return true;
+            return false;
         }
 
 #pragma warning disable CS0809


### PR DESCRIPTION
## Overview
The Push Notification Permission Status callback is an iOS only callback which differs from the Push Permission Response Received callback.
The Permission Status callback is called when `IsPushPermissionGranted` is called on iOS. The retrieving of the push permission status is asynchronous on iOS, so the permission status callback is used.

## Implementation
Implement the Push Notification Permission Status callback on iOS.

Fix the Push Permission Response Received callback on iOS and align its message with Android.