### PR TITLE
App inbox class

### DIFF
--- a/CleverTap/Plugins/iOS/CleverTapBinding.m
+++ b/CleverTap/Plugins/iOS/CleverTapBinding.m
@@ -445,7 +445,7 @@ char* CleverTap_getInboxMessageForId(const char* messageId) {
     id ret = [[CleverTapUnityManager sharedInstance] getInboxMessageForId:clevertap_stringToNSString(messageId)];
     NSString *jsonString = clevertap_toJsonString(ret);
     if (jsonString == nil) {
-        return NULL;
+        return clevertap_cStringCopy([@"{}" UTF8String]);
     }
     return clevertap_cStringCopy([jsonString UTF8String]);
 }

--- a/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
+++ b/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
@@ -125,6 +125,21 @@ namespace CleverTapSDK.Android {
 
             return json;
         }
+
+        internal override List<CleverTapInboxMessage> GetAllInboxMessagesParsed()
+        {
+            string jsonString = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getAllInboxMessages");
+            try
+            {
+                return CleverTapInboxMessageJSONParser.ParseJson(jsonString);
+            }
+            catch
+            {
+                CleverTapLogger.LogError("Unable to parse app inbox messages to CleverTapInboxMessage list.");
+                return new List<CleverTapInboxMessage>();
+            }
+        }
+
         internal override int GetInboxMessageCount() {
             return CleverTapAndroidJNI.CleverTapJNIInstance.Call<int>("getInboxMessageCount");
         }

--- a/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
+++ b/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
@@ -2,6 +2,7 @@
 using CleverTapSDK.Common;
 using CleverTapSDK.Constants;
 using CleverTapSDK.Utilities;
+using System;
 using System.Collections.Generic;
 
 namespace CleverTapSDK.Android {
@@ -109,6 +110,7 @@ namespace CleverTapSDK.Android {
             CleverTapAndroidJNI.CleverTapJNIInstance.Call("getCleverTapID");
             return string.Empty;
         }
+
         internal override JSONArray GetAllInboxMessages()
         {
             string jsonString = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getAllInboxMessages");
@@ -117,9 +119,9 @@ namespace CleverTapSDK.Android {
             {
                 json = (JSONArray)JSON.Parse(jsonString);
             }
-            catch
+            catch (Exception ex)
             {
-                CleverTapLogger.LogError("Unable to parse inbox messages JSON");
+                CleverTapLogger.LogError($"Unable to parse inbox messages JSON: {ex}.");
                 json = new JSONArray();
             }
 
@@ -131,11 +133,73 @@ namespace CleverTapSDK.Android {
             string jsonString = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getAllInboxMessages");
             try
             {
-                return CleverTapInboxMessageJSONParser.ParseJson(jsonString);
+                return CleverTapInboxMessageJSONParser.ParseJsonArray(jsonString);
             }
-            catch
+            catch (Exception ex)
             {
-                CleverTapLogger.LogError("Unable to parse app inbox messages to CleverTapInboxMessage list.");
+                CleverTapLogger.LogError($"Unable to parse inbox messages to CleverTapInboxMessage list: {ex}.");
+                return new List<CleverTapInboxMessage>();
+            }
+        }
+
+        internal override JSONClass GetInboxMessageForId(string messageId)
+        {
+            string jsonString = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getInboxMessageForId", messageId);
+            JSONClass json;
+            try
+            {
+                json = (JSONClass)JSON.Parse(jsonString);
+            }
+            catch (Exception ex)
+            {
+                CleverTapLogger.LogError($"Unable to parse inbox message for id: {messageId}. Exception: {ex}.");
+                json = new JSONClass();
+            }
+
+            return json;
+        }
+
+        internal override CleverTapInboxMessage GetInboxMessageForIdParsed(string messageId)
+        {
+            string jsonString = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getInboxMessageForId", messageId);
+            try
+            {
+                return CleverTapInboxMessageJSONParser.ParseJsonMessage(jsonString);
+            }
+            catch (Exception ex)
+            {
+                CleverTapLogger.LogError($"Unable to parse inbox message to CleverTapInboxMessage for id: {messageId}. Exception: {ex}.");
+                return null;
+            }
+        }
+
+        internal override JSONArray GetUnreadInboxMessages()
+        {
+            string jsonString = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getUnreadInboxMessages");
+            JSONArray json;
+            try
+            {
+                json = (JSONArray)JSON.Parse(jsonString);
+            }
+            catch (Exception ex)
+            {
+                CleverTapLogger.LogError($"Unable to parse unread inbox messages JSON: {ex}.");
+                json = new JSONArray();
+            }
+
+            return json;
+        }
+
+        internal override List<CleverTapInboxMessage> GetUnreadInboxMessagesParsed()
+        {
+            string jsonString = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getUnreadInboxMessages");
+            try
+            {
+                return CleverTapInboxMessageJSONParser.ParseJsonArray(jsonString);
+            }
+            catch (Exception ex)
+            {
+                CleverTapLogger.LogError($"Unable to parse unread inbox messages to CleverTapInboxMessage list: {ex}.");
                 return new List<CleverTapInboxMessage>();
             }
         }

--- a/CleverTap/Runtime/CleverTap.cs
+++ b/CleverTap/Runtime/CleverTap.cs
@@ -230,6 +230,9 @@ namespace CleverTapSDK {
         public static JSONClass GetInboxMessageForId(string messageId) =>
             cleverTapBinding.GetInboxMessageForId(messageId);
 
+        public static CleverTapInboxMessage GetInboxMessageForIdParsed(string messageId) =>
+            cleverTapBinding.GetInboxMessageForIdParsed(messageId);
+
         public static int GetInboxMessageUnreadCount() =>
             cleverTapBinding.GetInboxMessageUnreadCount();
 
@@ -241,6 +244,9 @@ namespace CleverTapSDK {
 
         public static JSONArray GetUnreadInboxMessages() =>
             cleverTapBinding.GetUnreadInboxMessages();
+
+        public static List<CleverTapInboxMessage> GetUnreadInboxMessagesParsed() =>
+            cleverTapBinding.GetUnreadInboxMessagesParsed();
 
         public static void InitializeInbox() =>
             cleverTapBinding.InitializeInbox();

--- a/CleverTap/Runtime/CleverTap.cs
+++ b/CleverTap/Runtime/CleverTap.cs
@@ -212,6 +212,9 @@ namespace CleverTapSDK {
         public static JSONArray GetAllInboxMessages() =>
             cleverTapBinding.GetAllInboxMessages();
 
+        public static List<CleverTapInboxMessage> GetAllInboxMessagesParsed() =>
+            cleverTapBinding.GetAllInboxMessagesParsed();
+
         public static string GetCleverTapID() =>
             cleverTapBinding.GetCleverTapID();
 

--- a/CleverTap/Runtime/Common/CleverTapInboxMessage.cs
+++ b/CleverTap/Runtime/Common/CleverTapInboxMessage.cs
@@ -11,6 +11,9 @@ namespace CleverTapSDK
         /// </summary>
         public string Id { get; set; }
 
+        /// <summary>
+        /// The inbox "msg" Message data.
+        /// </summary>
         public MessageData Message { get; set; }
 
         /// <summary>
@@ -29,12 +32,13 @@ namespace CleverTapSDK
         public DateTime? DateUtcDate => DateTs > 0 ? DateTimeOffset.FromUnixTimeSeconds(DateTs).UtcDateTime : null;
 
         /// <summary>
-        /// Returns the expiry timestamp of the inbox message.
+        /// Returns the expiry timestamp (time to live) of the inbox message or
+        /// 0 if time to live is set to infinite.
         /// </summary>
         public long ExpiresTs { get; set; }
 
         /// <summary>
-        /// Returns the expiry UTC date of the inbox message.
+        /// Returns the expiry UTC date of the inbox message or null if no expiry.
         /// </summary>
         public DateTime? ExpiresUtcDate => ExpiresTs > 0 ? DateTimeOffset.FromUnixTimeSeconds(ExpiresTs).UtcDateTime : null;
 
@@ -48,10 +52,34 @@ namespace CleverTapSDK
         #region Inbox Message nested classes
         public class MessageData
         {
+            /// <summary>
+            /// The inbox message type. Possible values are "simple",
+            /// "message-icon", "carousel", "carousel-image".
+            /// </summary>
             public string MessageType { get; set; }
+
+            /// <summary>
+            /// Returns true if tags are set in the inbox message.
+            /// </summary>
             public bool EnableTags { get; set; }
+
+            /// <summary>
+            /// The inbox content items.
+            /// For Simple Message and Icon Message templates the size of this List is by default 1.
+            /// For Carousel templates, the size of the List is the number of slides in the Carousel.
+            /// </summary>
             public List<Content> Content { get; set; }
+
+            /// <summary>
+            /// The inbox style Background Color.
+            /// </summary>
             public string BackgroundColor { get; set; }
+
+            /// <summary>
+            /// The inbox message orientation.
+            /// Returns "l" for landscape.
+            /// Returns "p" for portrait.
+            /// </summary>
             public string Orientation { get; set; }
 
             /// <summary>
@@ -65,13 +93,36 @@ namespace CleverTapSDK
             public List<CustomKV> CustomKeyValuePairs { get; set; }
         }
 
+        /// <summary>
+        /// The inbox message Content data.
+        /// </summary>
         public class Content
         {
             public long Key { get; set; }
+
+            /// <summary>
+            /// The inbox Message text and color.
+            /// </summary>
             public TextDetails Message { get; set; }
+
+            /// <summary>
+            /// The inbox Title text and color.
+            /// </summary>
             public TextDetails Title { get; set; }
+
+            /// <summary>
+            /// The inbox message Call to Action and Links.
+            /// </summary>
             public ActionDetails Action { get; set; }
+
+            /// <summary>
+            /// The inbox message main Image media data.
+            /// </summary>
             public Media Media { get; set; }
+
+            /// <summary>
+            /// The Inbox message Icon media data.
+            /// </summary>
             public Media Icon { get; set; }
         }
 
@@ -99,27 +150,63 @@ namespace CleverTapSDK
         /// </summary>
         public class Link
         {
+            /// <summary>
+            /// The Link type. Values could be "copy", "url", "kv".
+            /// </summary>
             public string Type { get; set; }
+
+            /// <summary>
+            /// The Link text.
+            /// </summary>
             public string Text { get; set; }
+
+            /// <summary>
+            /// The Link Text color.
+            /// </summary>
             public string Color { get; set; }
+
+            /// <summary>
+            /// The Link Fill color.
+            /// </summary>
             public string BackgroundColor { get; set; }
+
+            /// <summary>
+            /// The Copy to clipboard text value for "copy" type links.
+            /// </summary>
             public TextValue CopyText { get; set; }
+
+            /// <summary>
+            /// The Link URL for "Open URL" links.
+            /// </summary>
             public Url Url { get; set; }
+
+            /// <summary>
+            /// The Link Custom Key-Value pairs.
+            /// </summary>
             public Dictionary<string, string> KeyValuePairs { get; set; }
         }
 
+        /// <summary>
+        /// Text fields Text and Color.
+        /// </summary>
         public class TextDetails
         {
             public string Text { get; set; }
             public string Color { get; set; }
         }
 
+        /// <summary>
+        /// The URLs for iOS and Android.
+        /// </summary>
         public class Url
         {
             public TextValue Android { get; set; }
             public TextValue IOS { get; set; }
         }
 
+        /// <summary>
+        /// The Media data including URL and content type of the asset.
+        /// </summary>
         public class Media
         {
             public string Url { get; set; }
@@ -127,12 +214,18 @@ namespace CleverTapSDK
             public string ContentType { get; set; }
         }
 
+        /// <summary>
+        /// Custom Key-Value Pair.
+        /// </summary>
         public class CustomKV
         {
             public string Key { get; set; }
             public TextValue Value { get; set; }
         }
 
+        /// <summary>
+        /// The objects "text" value representation. 
+        /// </summary>
         public class TextValue
         {
             public string Text { get; set; }

--- a/CleverTap/Runtime/Common/CleverTapInboxMessage.cs
+++ b/CleverTap/Runtime/Common/CleverTapInboxMessage.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CleverTapSDK
+{
+    public class CleverTapInboxMessage
+    {
+        #region Inbox Message properties
+        /// <summary>
+        /// Returns the message identifier of the inbox message.
+        /// </summary>
+        public string Id { get; set; }
+
+        public MessageData Message { get; set; }
+
+        /// <summary>
+        /// Returns true if the inbox message is read.
+        /// </summary>
+        public bool IsRead { get; set; }
+
+        /// <summary>
+        /// Returns the delivery timestamp of the inbox message.
+        /// </summary>
+        public long DateTs { get; set; }
+
+        /// <summary>
+        /// Returns the delivery UTC date of the inbox message.
+        /// </summary>
+        public DateTime? DateUtcDate => DateTs > 0 ? DateTimeOffset.FromUnixTimeSeconds(DateTs).UtcDateTime : null;
+
+        /// <summary>
+        /// Returns the expiry timestamp of the inbox message.
+        /// </summary>
+        public long ExpiresTs { get; set; }
+
+        /// <summary>
+        /// Returns the expiry UTC date of the inbox message.
+        /// </summary>
+        public DateTime? ExpiresUtcDate => ExpiresTs > 0 ? DateTimeOffset.FromUnixTimeSeconds(ExpiresTs).UtcDateTime : null;
+
+        /// <summary>
+        /// Returns the campaign identifier.
+        /// </summary>
+        public string CampaignId { get; set; }
+
+        #endregion
+
+        #region Inbox Message nested classes
+        public class MessageData
+        {
+            public string MessageType { get; set; }
+            public bool EnableTags { get; set; }
+            public List<Content> Content { get; set; }
+            public string BackgroundColor { get; set; }
+            public string Orientation { get; set; }
+
+            /// <summary>
+            /// The inbox message Filter tags.
+            /// </summary>
+            public List<string> Tags { get; set; }
+
+            /// <summary>
+            /// The inbox message Custom Key-Value Pairs.
+            /// </summary>
+            public List<CustomKV> CustomKeyValuePairs { get; set; }
+        }
+
+        public class Content
+        {
+            public long Key { get; set; }
+            public TextDetails Message { get; set; }
+            public TextDetails Title { get; set; }
+            public ActionDetails Action { get; set; }
+            public Media Media { get; set; }
+            public Media Icon { get; set; }
+        }
+
+        /// <summary>
+        /// The inbox message Actions.
+        /// </summary>
+        public class ActionDetails
+        {
+            public bool HasUrl { get; set; }
+            public bool HasLinks { get; set; }
+
+            /// <summary>
+            /// The On Message Call to Action Url.
+            /// </summary>
+            public Url Url { get; set; }
+
+            /// <summary>
+            /// The inbox message On Link links.
+            /// </summary>
+            public List<Link> Links { get; set; }
+        }
+
+        /// <summary>
+        /// The inbox message Link.
+        /// </summary>
+        public class Link
+        {
+            public string Type { get; set; }
+            public string Text { get; set; }
+            public string Color { get; set; }
+            public string BackgroundColor { get; set; }
+            public TextValue CopyText { get; set; }
+            public Url Url { get; set; }
+            public Dictionary<string, string> KeyValuePairs { get; set; }
+        }
+
+        public class TextDetails
+        {
+            public string Text { get; set; }
+            public string Color { get; set; }
+        }
+
+        public class Url
+        {
+            public TextValue Android { get; set; }
+            public TextValue IOS { get; set; }
+        }
+
+        public class Media
+        {
+            public string Url { get; set; }
+            public string Key { get; set; }
+            public string ContentType { get; set; }
+        }
+
+        public class CustomKV
+        {
+            public string Key { get; set; }
+            public TextValue Value { get; set; }
+        }
+
+        public class TextValue
+        {
+            public string Text { get; set; }
+        }
+        #endregion
+    }
+}

--- a/CleverTap/Runtime/Common/CleverTapInboxMessage.cs.meta
+++ b/CleverTap/Runtime/Common/CleverTapInboxMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca8ffc03fef3c41d68df1eb0bfe364e1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Runtime/Common/CleverTapInboxMessageJSONParser.cs
+++ b/CleverTap/Runtime/Common/CleverTapInboxMessageJSONParser.cs
@@ -5,26 +5,48 @@ namespace CleverTapSDK
 {
     public class CleverTapInboxMessageJSONParser
     {
-        public static List<CleverTapInboxMessage> ParseJson(string jsonString)
+        public static List<CleverTapInboxMessage> ParseJsonArray(string jsonString)
         {
-            JSONArray jsonArray = JSON.Parse(jsonString).AsArray;
             var result = new List<CleverTapInboxMessage>();
+            if (string.IsNullOrEmpty(jsonString))
+                return result;
 
+            JSONArray jsonArray = JSON.Parse(jsonString).AsArray;
             foreach (JSONNode jsonNode in jsonArray)
             {
-                var root = new CleverTapInboxMessage
-                {
-                    Id = jsonNode["id"].Value != string.Empty ? jsonNode["id"] : jsonNode["_id"],
-                    Message = ParseMessageData(jsonNode["msg"]),
-                    IsRead = jsonNode["isRead"].AsBool,
-                    DateTs = jsonNode["date"].AsLong,
-                    ExpiresTs = jsonNode["wzrk_ttl"].AsLong,
-                    CampaignId = jsonNode["wzrk_id"]
-                };
-                result.Add(root);
+                var inboxMessage = ParseJsonNode(jsonNode);
+                if (inboxMessage != null)
+                    result.Add(inboxMessage);
             }
 
             return result;
+        }
+
+        public static CleverTapInboxMessage ParseJsonMessage(string jsonString)
+        {
+            if (string.IsNullOrEmpty(jsonString))
+                return null;
+
+            JSONNode jsonNode = JSON.Parse(jsonString);
+            return ParseJsonNode(jsonNode);
+        }
+
+        private static CleverTapInboxMessage ParseJsonNode(JSONNode jsonNode)
+        {
+            if (jsonNode == null || jsonNode.Count == 0)
+                return null;
+
+            var inboxMessage = new CleverTapInboxMessage
+            {
+                Id = jsonNode["id"].Value != string.Empty ? jsonNode["id"] : jsonNode["_id"],
+                Message = ParseMessageData(jsonNode["msg"]),
+                IsRead = jsonNode["isRead"].AsBool,
+                DateTs = jsonNode["date"].AsLong,
+                ExpiresTs = jsonNode["wzrk_ttl"].AsLong,
+                CampaignId = jsonNode["wzrk_id"]
+            };
+
+            return inboxMessage;
         }
 
         private static CleverTapInboxMessage.MessageData ParseMessageData(JSONNode msgNode)

--- a/CleverTap/Runtime/Common/CleverTapInboxMessageJSONParser.cs
+++ b/CleverTap/Runtime/Common/CleverTapInboxMessageJSONParser.cs
@@ -1,0 +1,172 @@
+﻿using System.Collections.Generic;
+using CleverTapSDK.Utilities;
+
+namespace CleverTapSDK
+{
+    public class CleverTapInboxMessageJSONParser
+    {
+        public static List<CleverTapInboxMessage> ParseJson(string jsonString)
+        {
+            JSONArray jsonArray = JSON.Parse(jsonString).AsArray;
+            var result = new List<CleverTapInboxMessage>();
+
+            foreach (JSONNode jsonNode in jsonArray)
+            {
+                var root = new CleverTapInboxMessage
+                {
+                    Id = jsonNode["id"].Value != string.Empty ? jsonNode["id"] : jsonNode["_id"],
+                    Message = ParseMessageData(jsonNode["msg"]),
+                    IsRead = jsonNode["isRead"].AsBool,
+                    DateTs = jsonNode["date"].AsLong,
+                    ExpiresTs = jsonNode["wzrk_ttl"].AsLong,
+                    CampaignId = jsonNode["wzrk_id"]
+                };
+                result.Add(root);
+            }
+
+            return result;
+        }
+
+        private static CleverTapInboxMessage.MessageData ParseMessageData(JSONNode msgNode)
+        {
+            return new CleverTapInboxMessage.MessageData
+            {
+                MessageType = msgNode["type"],
+                Content = ParseContentList(msgNode["content"].AsArray),
+                BackgroundColor = msgNode["bg"],
+                Orientation = msgNode["orientation"],
+                EnableTags = msgNode["enableTags"].AsBool,
+                Tags = ParseStringList(msgNode["tags"].AsArray),
+                CustomKeyValuePairs = ParseCustomKVList(msgNode["custom_kv"].AsArray)
+            };
+        }
+
+        private static List<CleverTapInboxMessage.Content> ParseContentList(JSONArray contentArray)
+        {
+            var contents = new List<CleverTapInboxMessage.Content>();
+            foreach (JSONNode item in contentArray)
+            {
+                var content = new CleverTapInboxMessage.Content
+                {
+                    Key = item["key"].AsLong,
+                    Message = ParseMessageDetails(item["message"]),
+                    Title = ParseMessageDetails(item["title"]),
+                    Action = ParseActionDetails(item["action"]),
+                    Media = ParseMedia(item["media"]),
+                    Icon = ParseMedia(item["icon"])
+                };
+                contents.Add(content);
+            }
+            return contents;
+        }
+
+        private static CleverTapInboxMessage.TextDetails ParseMessageDetails(JSONNode node)
+        {
+            return new CleverTapInboxMessage.TextDetails
+            {
+                Text = node["text"],
+                Color = node["color"]
+            };
+        }
+
+        private static CleverTapInboxMessage.ActionDetails ParseActionDetails(JSONNode node)
+        {
+            return new CleverTapInboxMessage.ActionDetails
+            {
+                HasUrl = node["hasUrl"].AsBool,
+                HasLinks = node["hasLinks"].AsBool,
+                Url = ParseUrl(node["url"]),
+                Links = ParseLinksList(node["links"].AsArray)
+            };
+        }
+
+        private static CleverTapInboxMessage.Url ParseUrl(JSONNode node)
+        {
+            return new CleverTapInboxMessage.Url
+            {
+                Android = ParseUrlText(node["android"]),
+                IOS = ParseUrlText(node["ios"])
+            };
+        }
+
+        private static CleverTapInboxMessage.TextValue ParseUrlText(JSONNode node)
+        {
+            return new CleverTapInboxMessage.TextValue
+            {
+                Text = node["text"]
+            };
+        }
+
+        private static List<CleverTapInboxMessage.Link> ParseLinksList(JSONArray linksArray)
+        {
+            var links = new List<CleverTapInboxMessage.Link>();
+            foreach (JSONNode item in linksArray)
+            {
+                var link = new CleverTapInboxMessage.Link
+                {
+                    Type = item["type"],
+                    Text = item["text"],
+                    Color = item["color"],
+                    BackgroundColor = item["bg"],
+                    CopyText = new CleverTapInboxMessage.TextValue { Text = item["copyText"]["text"] },
+                    Url = ParseUrl(item["url"]),
+                    KeyValuePairs = ParseDictionary(item["kv"])
+                };
+                links.Add(link);
+            }
+            return links;
+        }
+
+        private static CleverTapInboxMessage.Media ParseMedia(JSONNode node)
+        {
+            return new CleverTapInboxMessage.Media
+            {
+                Url = node["url"],
+                Key = node["key"],
+                ContentType = node["content_type"]
+            };
+        }
+
+        private static List<CleverTapInboxMessage.CustomKV> ParseCustomKVList(JSONArray customKvArray)
+        {
+            var customKvs = new List<CleverTapInboxMessage.CustomKV>();
+            foreach (JSONNode item in customKvArray)
+            {
+                var customKv = new CleverTapInboxMessage.CustomKV
+                {
+                    Key = item["key"],
+                    Value = new CleverTapInboxMessage.TextValue
+                    {
+                        Text = item["value"]["text"]
+                    }
+                };
+                customKvs.Add(customKv);
+            }
+            return customKvs;
+        }
+
+        private static List<string> ParseStringList(JSONArray array)
+        {
+            var list = new List<string>();
+            foreach (JSONNode item in array)
+            {
+                list.Add(item);
+            }
+            return list;
+        }
+
+        private static Dictionary<string, string> ParseDictionary(JSONNode node)
+        {
+            var dict = new Dictionary<string, string>();
+            if (node.Count == 0)
+                return dict;
+
+            JSONClass kv = node.AsObject;
+            foreach (KeyValuePair<string, JSONNode> pair in kv)
+            {
+                dict[pair.Key] = pair.Value.Value;
+            }
+            return dict;
+        }
+    }
+}

--- a/CleverTap/Runtime/Common/CleverTapInboxMessageJSONParser.cs.meta
+++ b/CleverTap/Runtime/Common/CleverTapInboxMessageJSONParser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: de5a4f3096840498e81aa316a4427e99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Runtime/Common/CleverTapPlatformBindings.cs
+++ b/CleverTap/Runtime/Common/CleverTapPlatformBindings.cs
@@ -97,6 +97,11 @@ namespace CleverTapSDK.Common {
             return new JSONArray();
         }
 
+        internal virtual List<CleverTapInboxMessage> GetAllInboxMessagesParsed()
+        {
+            return new List<CleverTapInboxMessage>();
+        }
+
         internal virtual string GetCleverTapID() {
             return string.Empty;
         }

--- a/CleverTap/Runtime/Common/CleverTapPlatformBindings.cs
+++ b/CleverTap/Runtime/Common/CleverTapPlatformBindings.cs
@@ -123,6 +123,11 @@ namespace CleverTapSDK.Common {
             return new JSONClass();
         }
 
+        internal virtual CleverTapInboxMessage GetInboxMessageForIdParsed(string messageId)
+        {
+            return null;
+        }
+
         internal virtual int GetInboxMessageUnreadCount() {
             return -1;
         }
@@ -137,6 +142,11 @@ namespace CleverTapSDK.Common {
 
         internal virtual JSONArray GetUnreadInboxMessages() {
             return new JSONArray();
+        }
+
+        internal virtual List<CleverTapInboxMessage> GetUnreadInboxMessagesParsed()
+        {
+            return new List<CleverTapInboxMessage>();
         }
 
         internal virtual void InitializeInbox() {

--- a/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
+++ b/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
@@ -103,6 +103,20 @@ namespace CleverTapSDK.IOS {
             return json;
         }
 
+        internal override List<CleverTapInboxMessage> GetAllInboxMessagesParsed()
+        {
+            string jsonString = IOSDllImport.CleverTap_getAllInboxMessages();
+            try
+            {
+                return CleverTapInboxMessageJSONParser.ParseJson(jsonString);
+            }
+            catch
+            {
+                CleverTapLogger.LogError("Unable to parse app inbox messages to CleverTapInboxMessage list.");
+                return new List<CleverTapInboxMessage>();
+            }
+        }
+
         internal override string GetCleverTapID() {
             return IOSDllImport.CleverTap_getCleverTapID();
         }

--- a/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
+++ b/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
@@ -2,6 +2,7 @@
 using CleverTapSDK.Common;
 using CleverTapSDK.Constants;
 using CleverTapSDK.Utilities;
+using System;
 using System.Collections.Generic;
 
 namespace CleverTapSDK.IOS {
@@ -91,13 +92,17 @@ namespace CleverTapSDK.IOS {
             return json;
         }
 
-        internal override JSONArray GetAllInboxMessages() {
+        internal override JSONArray GetAllInboxMessages()
+        {
             string jsonString = IOSDllImport.CleverTap_getAllInboxMessages();
             JSONArray json;
-            try {
+            try
+            {
                 json = (JSONArray)JSON.Parse(jsonString);
-            } catch {
-                CleverTapLogger.LogError("Unable to parse app inbox messages json");
+            }
+            catch (Exception ex)
+            {
+                CleverTapLogger.LogError($"Unable to parse app inbox messages json: {ex}");
                 json = new JSONArray();
             }
             return json;
@@ -108,11 +113,11 @@ namespace CleverTapSDK.IOS {
             string jsonString = IOSDllImport.CleverTap_getAllInboxMessages();
             try
             {
-                return CleverTapInboxMessageJSONParser.ParseJson(jsonString);
+                return CleverTapInboxMessageJSONParser.ParseJsonArray(jsonString);
             }
-            catch
+            catch (Exception ex)
             {
-                CleverTapLogger.LogError("Unable to parse app inbox messages to CleverTapInboxMessage list.");
+                CleverTapLogger.LogError($"Unable to parse app inbox messages to CleverTapInboxMessage list: {ex}");
                 return new List<CleverTapInboxMessage>();
             }
         }
@@ -141,16 +146,36 @@ namespace CleverTapSDK.IOS {
             return IOSDllImport.CleverTap_getInboxMessageCount();
         }
 
-        internal override JSONClass GetInboxMessageForId(string messageId) {
+        internal override JSONClass GetInboxMessageForId(string messageId)
+        {
             string jsonString = IOSDllImport.CleverTap_getInboxMessageForId(messageId);
+            CleverTapLogger.Log($"GetInboxMessageForId jsonString: {jsonString}");
             JSONClass json;
-            try {
+            try
+            {
                 json = (JSONClass)JSON.Parse(jsonString);
-            } catch {
-                CleverTapLogger.LogError("Unable to parse app inbox message json");
+            }
+            catch (Exception ex)
+            {
+                CleverTapLogger.LogError($"Unable to parse app inbox message json for id: {messageId}. Exception: {ex}.");
                 json = new JSONClass();
             }
             return json;
+        }
+
+        internal override CleverTapInboxMessage GetInboxMessageForIdParsed(string messageId)
+        {
+            string jsonString = IOSDllImport.CleverTap_getInboxMessageForId(messageId);
+            CleverTapLogger.Log($"GetInboxMessageForIdParsed jsonString: {jsonString}");
+            try
+            {
+                return CleverTapInboxMessageJSONParser.ParseJsonMessage(jsonString);
+            }
+            catch (Exception ex)
+            {
+                CleverTapLogger.LogError($"Unable to parse inbox message to CleverTapInboxMessage for id: {messageId}. Exception: {ex}.");
+                return null;
+            }
         }
 
         internal override int GetInboxMessageUnreadCount() {
@@ -173,16 +198,34 @@ namespace CleverTapSDK.IOS {
             return json;
         }
 
-        internal override JSONArray GetUnreadInboxMessages() {
+        internal override JSONArray GetUnreadInboxMessages()
+        {
             string jsonString = IOSDllImport.CleverTap_getUnreadInboxMessages();
             JSONArray json;
-            try {
+            try
+            {
                 json = (JSONArray)JSON.Parse(jsonString);
-            } catch {
-                CleverTapLogger.LogError("Unable to parse unread app inbox messages json");
+            }
+            catch (Exception ex)
+            {
+                CleverTapLogger.LogError($"Unable to parse unread inbox messages json: {ex}.");
                 json = new JSONArray();
             }
             return json;
+        }
+
+        internal override List<CleverTapInboxMessage> GetUnreadInboxMessagesParsed()
+        {
+            string jsonString = IOSDllImport.CleverTap_getUnreadInboxMessages();
+            try
+            {
+                return CleverTapInboxMessageJSONParser.ParseJsonArray(jsonString);
+            }
+            catch (Exception ex)
+            {
+                CleverTapLogger.LogError($"Unable to parse unread inbox messages to CleverTapInboxMessage list: {ex}");
+                return new List<CleverTapInboxMessage>();
+            }
         }
 
         internal override void InitializeInbox() {

--- a/CleverTap/Runtime/Utilities/SimpleJSON.cs
+++ b/CleverTap/Runtime/Utilities/SimpleJSON.cs
@@ -114,6 +114,22 @@ namespace CleverTapSDK.Utilities
                 Value = value.ToString();
             }
         }
+
+        public virtual long AsLong
+        {
+            get
+            {
+                long v = 0;
+                if (long.TryParse(Value, out v))
+                    return v;
+                return 0;
+            }
+            set
+            {
+                Value = value.ToString();
+            }
+        }
+
         public virtual float AsFloat
         {
             get


### PR DESCRIPTION
## Overview
Implement App Inbox models and JSON parsing.

## Implementation
Parse the inbox messages JSON using SimpleJSON. 
Using `SimpleJSON` instead of `UnityEngine.JsonUtility` since the inbox message contains dynamic dictionary for the custom key-value pairs `"kv"`. Consider using `com.unity.nuget.newtonsoft-json` package to parse directly, in the future, based on Unity Editor support.

Add new "Parsed" methods for backward compatibility - `GetAllInboxMessagesParsed`, `GetUnreadInboxMessagesParsed`, `GetInboxMessageForIdParsed`.

Add missing `GetUnreadInboxMessages` and `GetInboxMessageForId` in the Android bindings.