### PR TITLE
IOS Auto Integrate and Push Notifications

### DIFF
--- a/CTExample/Assets/Scripts/App.cs
+++ b/CTExample/Assets/Scripts/App.cs
@@ -40,6 +40,9 @@ namespace CTExample
 
             // Add listeners for events that may be triggered on app launch
             CleverTap.OnCleverTapPushOpenedCallback += CleverTapPushOpenedCallback;
+#if UNITY_IOS
+            CleverTap.OnCleverTapPushNotificationTappedWithCustomExtrasCallback += CleverTap_OnCleverTapPushNotificationTappedWithCustomExtrasCallback;
+#endif
             CleverTap.OnCleverTapDeepLinkCallback += CleverTapDeepLinkCallback;
             CleverTap.OnCleverTapInAppNotificationShowCallback += CleverTapInAppNotificationShowCallback;
             CleverTap.OnCleverTapInAppNotificationButtonTapped += CleverTapInAppNotificationButtonTapped;
@@ -62,6 +65,11 @@ namespace CTExample
         private void CleverTapPushOpenedCallback(string message)
         {
             Logger.Log($"Push Opened callback: {message}");
+        }
+
+        private void CleverTap_OnCleverTapPushNotificationTappedWithCustomExtrasCallback(string message)
+        {
+            Logger.Log($"Push Tapped with Custom extras callback: {message}");
         }
 
         private void CleverTapDeepLinkCallback(string message)

--- a/CleverTap/Editor/CleverTapSettings.cs
+++ b/CleverTap/Editor/CleverTapSettings.cs
@@ -6,10 +6,13 @@ public class CleverTapSettings : ScriptableObject
     public string CleverTapAccountId;
     public string CleverTapAccountToken;
     public string CleverTapAccountRegion;
-    public bool CleverTapEnablePersonalization { get; set; } = true;
-    public bool CleverTapDisableIDFV;
     public string CleverTapProxyDomain;
     public string CleverTapSpikyProxyDomain;
+    public bool CleverTapDisableIDFV;
+
+    public bool CleverTapIOSUseAutoIntegrate { get; set; } = true;
+    public bool CleverTapIOSUseUNUserNotificationCenter { get; set; } = true;
+    public bool CleverTapIOSPresentNotificationOnForeground;
 
     public override string ToString()
     {
@@ -19,8 +22,10 @@ public class CleverTapSettings : ScriptableObject
                $"CleverTapAccountRegion: {CleverTapAccountRegion}\n" +
                $"CleverTapProxyDomain: {CleverTapProxyDomain}\n" +
                $"CleverTapSpikyProxyDomain: {CleverTapSpikyProxyDomain}\n" +
-               $"CleverTapEnablePersonalization: {CleverTapEnablePersonalization}\n" +
-               $"CleverTapDisableIDFV: {CleverTapDisableIDFV}";
+               $"CleverTapDisableIDFV: {CleverTapDisableIDFV}\n" +
+               $"CleverTapIOSUseAutoIntegrate: {CleverTapIOSUseAutoIntegrate}\n" +
+               $"CleverTapIOSUseUNUserNotificationCenter: {CleverTapIOSUseUNUserNotificationCenter}\n" +
+               $"CleverTapIOSPresentNotificationOnForeground: {CleverTapIOSPresentNotificationOnForeground}";
     }
 
     internal static readonly string settingsPath = "Assets/CleverTapSettings.asset";

--- a/CleverTap/Editor/CleverTapSettingsWindow.cs
+++ b/CleverTap/Editor/CleverTapSettingsWindow.cs
@@ -30,6 +30,9 @@ namespace CleverTapSDK.Private
                 return;
             }
 
+            float originalValue = EditorGUIUtility.labelWidth;
+            EditorGUIUtility.labelWidth = 180;
+
             GUILayout.Label(windowName, EditorStyles.boldLabel);
 
             settings.CleverTapAccountId = EditorGUILayout.TextField("CleverTapAccountId", settings.CleverTapAccountId);
@@ -38,8 +41,13 @@ namespace CleverTapSDK.Private
             settings.CleverTapProxyDomain = EditorGUILayout.TextField("CleverTapProxyDomain", settings.CleverTapProxyDomain);
             settings.CleverTapSpikyProxyDomain = EditorGUILayout.TextField("CleverTapSpikyProxyDomain", settings.CleverTapSpikyProxyDomain);
 
-            settings.CleverTapEnablePersonalization = EditorGUILayout.Toggle("CleverTapEnablePersonalization", settings.CleverTapEnablePersonalization);
+            GUILayout.Label("iOS specific settings", EditorStyles.boldLabel);
             settings.CleverTapDisableIDFV = EditorGUILayout.Toggle("CleverTapDisableIDFV", settings.CleverTapDisableIDFV);
+            settings.CleverTapIOSUseAutoIntegrate = EditorGUILayout.Toggle("UseAutoIntegrate", settings.CleverTapIOSUseAutoIntegrate);
+            settings.CleverTapIOSUseUNUserNotificationCenter = EditorGUILayout.Toggle("UseUNUserNotificationCenter", settings.CleverTapIOSUseUNUserNotificationCenter);
+            settings.CleverTapIOSPresentNotificationOnForeground = EditorGUILayout.Toggle("PresentNotificationForeground", settings.CleverTapIOSPresentNotificationOnForeground);
+
+            EditorGUIUtility.labelWidth = originalValue;
 
             if (GUILayout.Button("Save Settings"))
             {

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.h
@@ -1,9 +1,12 @@
 #import <Foundation/Foundation.h>
 #import "UnityAppController.h"
+#import <UserNotifications/UserNotifications.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface CleverTapUnityAppController : UnityAppController
+@interface CleverTapUnityAppController : UnityAppController <UNUserNotificationCenterDelegate>
+
+@property (nonatomic) BOOL presentNotificationInForeground;
 
 @end
 

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
@@ -14,9 +14,6 @@
 #pragma mark - CleverTapUnityAppController
 @implementation CleverTapUnityAppController
 
-static NSDictionary *notificationFromLaunch;
-static NSTimeInterval launchTime;
-
 #pragma mark - application:didFinishLaunchingWithOptions:
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     // Register Custom Templates
@@ -49,13 +46,6 @@ static NSTimeInterval launchTime;
     // Initialize the CleverTapUnityManager
     [CleverTapUnityManager sharedInstance];
     
-    // Handle app launched with remote notification
-    NSDictionary *userInfo = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
-    if (userInfo) {
-        notificationFromLaunch = userInfo;
-        launchTime = [[NSDate date] timeIntervalSince1970];
-        [[CleverTapUnityManager sharedInstance] sendRemoteNotificationCallbackToUnity:userInfo isOpen:YES];
-    }
     // Return super application:didFinishLaunchingWithOptions:
     return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
@@ -85,16 +75,8 @@ static NSTimeInterval launchTime;
     [[CleverTapUnityManager sharedInstance] didReceiveRemoteNotification:userInfo
                                                                   isOpen:YES openInForeground:YES];
 #else
-    // Prevent duplicate handling in case the app is launched with the remote notification
-    BOOL isNotificationFromLaunch = notificationFromLaunch &&
-    [notificationFromLaunch isEqualToDictionary:userInfo] &&
-    launchTime + 1.000 > [[NSDate date] timeIntervalSince1970];
-    
-    if (!isNotificationFromLaunch) {
-        [[CleverTapUnityManager sharedInstance]
-         sendRemoteNotificationCallbackToUnity:userInfo isOpen:YES];
-    }
-    notificationFromLaunch = nil;
+    [[CleverTapUnityManager sharedInstance]
+     sendRemoteNotificationCallbackToUnity:userInfo isOpen:YES];
 #endif
     completionHandler();
 }

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
@@ -60,6 +60,11 @@ static NSTimeInterval launchTime;
     return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options {
+    [[CleverTapUnityManager sharedInstance] handleOpenURL:url];
+    return [super application:app openURL:url options:options];
+}
+
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     BOOL isOpen = application.applicationState == UIApplicationStateActive ? NO : YES;
 #ifdef NO_AUTOINTEGRATE

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
@@ -3,13 +3,150 @@
 #import "CleverTapCustomTemplates.h"
 #import <CleverTapSDK/CleverTap.h>
 
+#pragma mark - Constants
+#define CT_ACCOUNT_ID_LABEL @"CleverTapAccountID"
+#define CT_TOKEN_LABEL @"CleverTapToken"
+#define CT_REGION_LABEL @"CleverTapRegion"
+#define CT_PROXY_DOMAIN_LABEL @"CleverTapProxyDomain"
+#define CT_SPIKY_PROXY_DOMAIN_LABEL @"CleverTapSpikyProxyDomain"
+#define CT_PRESENT_NOTIF_FOREGROUND @"CleverTapPresentNotificationForeground"
+
+#pragma mark - CleverTapUnityAppController
 @implementation CleverTapUnityAppController
 
+static NSDictionary *notificationFromLaunch;
+static NSTimeInterval launchTime;
+
+#pragma mark - application:didFinishLaunchingWithOptions:
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Register Custom Templates
     [CleverTapCustomTemplates registerCustomTemplates];
+    
+#if !NO_UNUSERNOTIFICATIONCENTER
+    // Set UNUserNotificationCenter delegate to self based on settings
+    [UNUserNotificationCenter currentNotificationCenter].delegate = (id <UNUserNotificationCenterDelegate>)self;
+    
+    NSString *presentNotificationInForegroundMeta = [self getMetaDataForAttribute:CT_PRESENT_NOTIF_FOREGROUND];
+    self.presentNotificationInForeground = [presentNotificationInForegroundMeta boolValue];
+#endif
+    
+#ifdef NO_AUTOINTEGRATE
+    NSString *_accountId = [self getMetaDataForAttribute:CT_ACCOUNT_ID_LABEL];
+    NSString *_accountToken = [self getMetaDataForAttribute:CT_TOKEN_LABEL];
+    NSString *_accountRegion = [self getMetaDataForAttribute:CT_REGION_LABEL];
+    NSString *_proxyDomain = [self getMetaDataForAttribute:CT_PROXY_DOMAIN_LABEL];
+    NSString *_spikyProxyDomain = [self getMetaDataForAttribute:CT_SPIKY_PROXY_DOMAIN_LABEL];
+    if (_accountRegion) {
+        [CleverTap setCredentialsWithAccountID:_accountId token:_accountToken region:_accountRegion];
+    } else {
+        [CleverTap setCredentialsWithAccountID:_accountId token:_accountToken proxyDomain:_proxyDomain spikyProxyDomain:_spikyProxyDomain];
+    }
+    [[CleverTap sharedInstance] notifyApplicationLaunchedWithOptions:launchOptions];
+#else
+    // Use Auto Integrate
     [CleverTap autoIntegrate];
+#endif
+    // Initialize the CleverTapUnityManager
     [CleverTapUnityManager sharedInstance];
+    
+    // Handle app launched with remote notification
+    NSDictionary *userInfo = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
+    if (userInfo) {
+        notificationFromLaunch = userInfo;
+        launchTime = [[NSDate date] timeIntervalSince1970];
+        [[CleverTapUnityManager sharedInstance] sendRemoteNotificationCallbackToUnity:userInfo isOpen:YES];
+    }
+    // Return super application:didFinishLaunchingWithOptions:
     return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    BOOL isOpen = application.applicationState == UIApplicationStateActive ? NO : YES;
+#ifdef NO_AUTOINTEGRATE
+    // Handle the push notification
+    [[CleverTapUnityManager sharedInstance] didReceiveRemoteNotification:userInfo isOpen:isOpen openInForeground:NO];
+#else
+    // Send callback to unity
+    [[CleverTapUnityManager sharedInstance] sendRemoteNotificationCallbackToUnity:userInfo isOpen:isOpen];
+#endif
+    [super application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+}
+
+#pragma mark - UNUserNotificationCenter methods
+#if !NO_UNUSERNOTIFICATIONCENTER
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler {
+    NSDictionary *userInfo = response.notification.request.content.userInfo;
+#ifdef NO_AUTOINTEGRATE
+    [[CleverTapUnityManager sharedInstance] didReceiveRemoteNotification:userInfo
+                                                                  isOpen:YES openInForeground:YES];
+#else
+    // Prevent duplicate handling in case the app is launched with the remote notification
+    BOOL isNotificationFromLaunch = notificationFromLaunch &&
+    [notificationFromLaunch isEqualToDictionary:userInfo] &&
+    launchTime + 1.000 > [[NSDate date] timeIntervalSince1970];
+    
+    if (!isNotificationFromLaunch) {
+        [[CleverTapUnityManager sharedInstance]
+         sendRemoteNotificationCallbackToUnity:userInfo isOpen:YES];
+    }
+    notificationFromLaunch = nil;
+#endif
+    completionHandler();
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler {
+    if (self.presentNotificationInForeground) {
+        [[CleverTapUnityManager sharedInstance]
+         sendRemoteNotificationCallbackToUnity:notification.request.content.userInfo isOpen:NO];
+        if (@available(iOS 14.0, *)) {
+            completionHandler(UNNotificationPresentationOptionBanner | UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionSound);
+        } else {
+            completionHandler(UNNotificationPresentationOptionAlert | UNNotificationPresentationOptionBadge | UNNotificationPresentationOptionSound);
+        }
+    } else {
+        [[CleverTapUnityManager sharedInstance] didReceiveRemoteNotification:notification.request.content.userInfo isOpen:YES openInForeground:YES];
+        completionHandler(UNNotificationPresentationOptionNone);
+    }
+}
+#endif
+
+#pragma mark - No Auto Integrate Push Registration
+#ifdef NO_AUTOINTEGRATE
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    [[CleverTapUnityManager sharedInstance] setPushToken:deviceToken];
+    [super application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    NSLog(@"Failed to register for remote notifications: %@", error);
+    [super application:application didFailToRegisterForRemoteNotificationsWithError:error];
+}
+#endif
+
+#pragma mark - Utils
+static NSDictionary *plistRootInfoDict;
+
+- (id)getValueForKey:(NSString *)key {
+    if (!plistRootInfoDict) {
+        plistRootInfoDict = [[NSBundle mainBundle] infoDictionary];
+    }
+    return plistRootInfoDict[key];
+}
+
+- (NSString *)getMetaDataForAttribute:(NSString *)name {
+    id _value = [self getValueForKey:name];
+    
+    if(_value && ![_value isKindOfClass:[NSString class]]) {
+        _value = [NSString stringWithFormat:@"%@", _value];
+    }
+    
+    NSString *value = (NSString *)_value;
+    if (value == nil || [[value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] isEqualToString:@""]) {
+        value = nil;
+    } else {
+        value = [value stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+    }
+    return value;
 }
 
 @end

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.h
@@ -7,13 +7,14 @@
 #import <CleverTapSDK/CleverTap+ProductConfig.h>
 #import <CleverTapSDK/CleverTapInAppNotificationDelegate.h>
 #import <CleverTapSDK/Clevertap+PushPermission.h>
+#import <CleverTapSDK/CleverTapPushNotificationDelegate.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CleverTapUnityCallbackHandler : NSObject 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-<CleverTapInAppNotificationDelegate, CleverTapDisplayUnitDelegate, CleverTapInboxViewControllerDelegate, CleverTapProductConfigDelegate, CleverTapFeatureFlagsDelegate, CleverTapPushPermissionDelegate>
+<CleverTapInAppNotificationDelegate, CleverTapDisplayUnitDelegate, CleverTapInboxViewControllerDelegate, CleverTapProductConfigDelegate, CleverTapFeatureFlagsDelegate, CleverTapPushPermissionDelegate, CleverTapPushNotificationDelegate>
 
 #pragma clang diagnostic pop
 
@@ -35,8 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (CleverTapInboxUpdatedBlock)inboxUpdatedBlock;
 
-- (void)didReceiveRemoteNotification:(UIApplicationState)applicationState data:(NSData *)data;
-    
+- (void)didReceiveRemoteNotification:(NSData *)data isOpen:(BOOL)isOpen;
+
 - (void)deepLinkCallback:(NSString *)url;
 
 @end

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackHandler.mm
@@ -20,6 +20,7 @@
 - (void)attachInstance:(CleverTap *)instance {
     [self registerListeners];
     
+    [instance setPushNotificationDelegate:self];
     [instance setInAppNotificationDelegate:self];
     [instance setDisplayUnitDelegate:self];
     [instance setPushPermissionDelegate:self];
@@ -53,12 +54,19 @@
 
 #pragma mark - Remote Notification
 
-- (void)didReceiveRemoteNotification:(UIApplicationState)applicationState data:(NSData *)data {
+- (void)didReceiveRemoteNotification:(NSData *)data isOpen:(BOOL)isOpen {
     NSString *dataString = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     
-    CleverTapUnityCallback callback = (applicationState == UIApplicationStateActive) ? CleverTapUnityCallbackPushReceived : CleverTapUnityCallbackPushOpened;
+    // CleverTapUnityCallbackPushReceived is not implemented and not supported
+    if (!isOpen)
+        return;
     
-    [self callUnityObject:callback withMessage:dataString];
+    [self callUnityObject:CleverTapUnityCallbackPushOpened withMessage:dataString];
+}
+
+- (void)pushNotificationTappedWithCustomExtras:(NSDictionary *)customExtras {
+    NSString *json = [self dictToJson:customExtras];
+    [self callUnityObject:CleverTapUnityCallbackPushNotificationTappedWithCustomExtras withMessage:json];
 }
 
 #pragma mark - Deeplink

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h
@@ -6,7 +6,7 @@ typedef NS_ENUM(NSInteger, CleverTapUnityCallback) {
     CleverTapUnityCallbackProfileInitialized = 0,
     CleverTapUnityCallbackProfileUpdates = 1,
     CleverTapUnityCallbackDeepLink = 2,
-    CleverTapUnityCallbackPushReceived = 3,
+    CleverTapUnityCallbackPushNotificationTappedWithCustomExtras = 3,
     CleverTapUnityCallbackPushOpened = 4,
     CleverTapUnityCallbackInAppNotificationDismissed = 5,
     CleverTapUnityCallbackInAppNotificationButtonTapped = 6,

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
@@ -36,7 +36,7 @@
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileInitializedCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileUpdatesCallback" bufferable:NO],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapDeepLinkCallback" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushReceivedCallback" bufferable:YES],
+            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushNotificationTappedWithCustomExtrasCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushOpenedCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationDismissedCallback" bufferable:YES],
             [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationButtonTapped" bufferable:YES],

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.h
@@ -72,7 +72,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setPushToken:(NSData *)pushToken;
 - (void)setPushTokenAsString:(NSString *)pushTokenString;
-- (void)registerApplication:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification;
+- (void)didReceiveRemoteNotification:(NSDictionary *)notification
+                              isOpen:(BOOL)isOpen
+                    openInForeground:(BOOL)openInForeground;
+- (void)sendRemoteNotificationCallbackToUnity:(NSDictionary *)notification isOpen:(BOOL)isOpen;
 
 - (void)handleOpenURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication;
 - (void)pushInstallReferrerSource:(NSString *)source

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.h
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
                     openInForeground:(BOOL)openInForeground;
 - (void)sendRemoteNotificationCallbackToUnity:(NSDictionary *)notification isOpen:(BOOL)isOpen;
 
-- (void)handleOpenURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication;
+- (void)handleOpenURL:(NSURL *)url;
 - (void)pushInstallReferrerSource:(NSString *)source
                            medium:(NSString *)medium
                          campaign:(NSString *)campaign;

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -317,7 +317,7 @@ const int PENDING_EVENTS_TIME_OUT = 5;
 
 #pragma mark - DeepLink Handling
 
-- (void)handleOpenURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication {
+- (void)handleOpenURL:(NSURL *)url {
     [[CleverTapUnityCallbackHandler sharedInstance] deepLinkCallback:[url absoluteString]];
 }
 

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -39,6 +39,7 @@
     if (self = [super init]) {
         self.cleverTap = [CleverTap sharedInstance];
         NSLog(@"CleverTap default instance: %@", self.cleverTap);
+        [self.cleverTap setLibrary:@"Unity"];
         self.callbackHandler = [CleverTapUnityCallbackHandler sharedInstance];
         [self.callbackHandler attachInstance:self.cleverTap];
         [self disableMessageBuffers];
@@ -269,13 +270,23 @@ const int PENDING_EVENTS_TIME_OUT = 5;
     [self.cleverTap setPushTokenAsString:pushTokenString];
 }
 
-- (void)handleNotificationWithData:(id)data {
-    [self.cleverTap handleNotificationWithData:data];
+- (void)didReceiveRemoteNotification:(NSDictionary *)notification isOpen:(BOOL)isOpen {
+    [self didReceiveRemoteNotification:notification isOpen:isOpen openInForeground:NO];
 }
 
-- (void)registerApplication:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
-    [self handleNotificationWithData:notification];
-    
+- (void)didReceiveRemoteNotification:(NSDictionary *)notification
+                              isOpen:(BOOL)isOpen
+           openInForeground:(BOOL)openInForeground {
+    if (openInForeground) {
+        [self.cleverTap handleNotificationWithData:notification openDeepLinksInForeground:YES];
+    } else {
+        [self.cleverTap handleNotificationWithData:notification];
+    }
+
+    [self sendRemoteNotificationCallbackToUnity:notification isOpen:isOpen];
+}
+
+- (void)sendRemoteNotificationCallbackToUnity:(NSDictionary *)notification isOpen:(BOOL)isOpen {
     // generate a new dictionary that rearrange the notification elements
     NSMutableDictionary *aps = [NSMutableDictionary dictionaryWithDictionary:[notification objectForKey:@"aps"]];
     
@@ -299,11 +310,10 @@ const int PENDING_EVENTS_TIME_OUT = 5;
         
         if (pushParsingError == nil) {
             [[CleverTapUnityCallbackHandler sharedInstance]
-             didReceiveRemoteNotification:application.applicationState data:data];
+             didReceiveRemoteNotification:data isOpen:isOpen];
         }
     }
 }
-
 
 #pragma mark - DeepLink Handling
 

--- a/CleverTap/Runtime/CleverTap.cs
+++ b/CleverTap/Runtime/CleverTap.cs
@@ -48,6 +48,12 @@ namespace CleverTapSDK {
             remove => cleverTapCallbackHandler.OnCleverTapPushOpenedCallback -= value;
         }
 
+        public static event CleverTapCallbackWithMessageDelegate OnCleverTapPushNotificationTappedWithCustomExtrasCallback
+        {
+            add => cleverTapCallbackHandler.OnCleverTapPushNotificationTappedWithCustomExtrasCallback += value;
+            remove => cleverTapCallbackHandler.OnCleverTapPushNotificationTappedWithCustomExtrasCallback -= value;
+        }
+
         public static event CleverTapCallbackWithMessageDelegate OnCleverTapInitCleverTapIdCallback {
             add => cleverTapCallbackHandler.OnCleverTapInitCleverTapIdCallback += value;
             remove => cleverTapCallbackHandler.OnCleverTapInitCleverTapIdCallback -= value;

--- a/CleverTap/Runtime/Common/CleverTapCallbackHandler.cs
+++ b/CleverTap/Runtime/Common/CleverTapCallbackHandler.cs
@@ -91,6 +91,26 @@ namespace CleverTapSDK.Common {
             }
         }
 
+        private CleverTapCallbackWithMessageDelegate _OnCleverTapPushNotificationTappedWithCustomExtrasCallback;
+        public event CleverTapCallbackWithMessageDelegate OnCleverTapPushNotificationTappedWithCustomExtrasCallback
+        {
+            add
+            {
+                lock (CallbackLock)
+                {
+                    _OnCleverTapPushNotificationTappedWithCustomExtrasCallback += value;
+                    OnCallbackAdded(CleverTapPushNotificationTappedWithCustomExtrasCallback);
+                }
+            }
+            remove
+            {
+                lock (CallbackLock)
+                {
+                    _OnCleverTapPushNotificationTappedWithCustomExtrasCallback -= value;
+                }
+            }
+        }
+
         private CleverTapCallbackWithMessageDelegate _OnCleverTapInitCleverTapIdCallback;
         public event CleverTapCallbackWithMessageDelegate OnCleverTapInitCleverTapIdCallback
         {
@@ -554,18 +574,53 @@ namespace CleverTapSDK.Common {
             }
         }
 
-        // returns the data associated with the push notification
-        public virtual void CleverTapPushOpenedCallback(string message) {
-            CleverTapLogger.Log("unity received push opened: " + (!String.IsNullOrEmpty(message) ? message : "NULL"));
-            if (String.IsNullOrEmpty(message)) {
+        /// <summary>
+        /// Callback when a push notitication is opened.
+        /// </summary>
+        /// <param name="message">The data associated with the push notification message.</param>
+        public virtual void CleverTapPushOpenedCallback(string message)
+        {
+            CleverTapLogger.Log("unity received push opened: " + (!string.IsNullOrEmpty(message) ? message : "NULL"));
+            if (string.IsNullOrEmpty(message))
+            {
                 return;
             }
 
-            try {
+            try
+            {
                 JSONClass json = (JSONClass)JSON.Parse(message);
-                CleverTapLogger.Log(String.Format("push notification data is {0}", json));
+                CleverTapLogger.Log(string.Format("push notification data is {0}", json));
                 _OnCleverTapPushOpenedCallback?.Invoke(message);
-            } catch {
+            }
+            catch
+            {
+                CleverTapLogger.LogError("unable to parse json");
+            }
+        }
+
+        /// <summary>
+        /// IOS only callback. Called when a push notitication is opened.
+        /// </summary>
+        /// <param name="message">
+        /// The push notification user info without the "aps" param.
+        /// It contains extra key/value pairs set in the CleverTap dashboard for this notification
+        /// </param>
+        public virtual void CleverTapPushNotificationTappedWithCustomExtrasCallback(string message)
+        {
+            CleverTapLogger.Log("unity received push tapped with custom extras: " + (!string.IsNullOrEmpty(message) ? message : "NULL"));
+            if (string.IsNullOrEmpty(message))
+            {
+                return;
+            }
+
+            try
+            {
+                JSONClass json = (JSONClass)JSON.Parse(message);
+                CleverTapLogger.Log(string.Format("push notification data is {0}", json));
+                _OnCleverTapPushNotificationTappedWithCustomExtrasCallback?.Invoke(message);
+            }
+            catch
+            {
                 CleverTapLogger.LogError("unable to parse json");
             }
         }


### PR DESCRIPTION
## Overview
Initialize the iOS SDK using `[CleverTap autoIntegrate]`. This swizzles the application and push notification methods automatically. 
Allows initialization without `autoIntegrate` using `[CleverTap setCredentialsWithAccountID:...]` in case swizzling should not be used. This allows backward compatibility with the previous setup but also brings improvements.
Ensures Unity `CleverTapUnityCallbackPushOpened` callback is executed correctly.
Adds the `CleverTapUnityCallbackPushNotificationTappedWithCustomExtras` callback which relies on the iOS SDK using the `CleverTapPushNotificationDelegate`.
Adds the `CleverTapIOSPresentNotificationOnForeground` option which allows handling the push notification on foreground or presenting it as a banner/alert.

## Implementation
Auto Integration relies on the iOS SDK to handle the push notifications. It still implements the push notification methods so the `CleverTapUnityCallbackPushOpened` callback can be supported.

If Auto Integration is disabled, the push notification methods call the iOS SDK to handle the push notifications (since swizzling is not enabled and the SDK won't handle the push notifications otherwise).

The `UNUserNotificationCenter` delegate is required so notifications can be handled correctly. It is needed for both autoIntegrations and not.
If you implement the delegate in your own class, you can disable the use of the `UNUserNotificationCenter` delegate. In this case, you MUST implement the methods yourself and call the CleverTap methods.

If `CleverTapIOSPresentNotificationOnForeground` is `false`, the notification will be handled without presenting it, if it has a deeplink, it will be opened. If the setting is `true`, the notification will be presented using `banner/alert | sound | badge`. See the `userNotificationCenter:willPresentNotification:withCompletionHandler` method for details.

It is recommended to use the new `CleverTapUnityCallbackPushNotificationTappedWithCustomExtras` callback since it comes from the iOS SDK. However, it sends only the custom extras ie the additional push data such as `wzrk` keys and custom key-value pairs. 
The `CleverTapUnityCallbackPushOpened` callback sends the whole notification user info including the `aps` data. This is why implementation is adjusted to keep backwards compatibility.

Adds the `CleverTapIOSUseAutoIntegrate`, `CleverTapIOSUseUNUserNotificationCenter` and `CleverTapIOSPresentNotificationOnForeground` settings.
AutoIntegrate and NotificationCenter are enabled by default. Both settings use a preprocessor macro to enable/disable code in the `CleverTapUnityAppController`. The preprocessor flags are set using the `IOSPostBuildProcessor.cs`.
The `CleverTapIOSPresentNotificationOnForeground` setting is a plist flag.

## Notes
Removes the modification and inserting code in the `UnityAppController`. This is now handled by the `CleverTapUnityAppController`. 
The openURL and local notification methods were not working before. Local notifications and the `application:openURL:sourceApplication:` are deprecated. The `application:openURL:options:` is used now.

The `CleverTapUnityCallbackPushReceived` callback has never been supported on iOS and C# APIs and is not available on Android, hence it has been removed.

Removes the `CleverTapEnablePersonalization` setting. Personalization is enabled by default. The setting did not disable personalization if set to false in the settings. It can be disabled by calling the `DisablePersonalization` method.

Push notifications integration no longer requires the Unity Mobile Notifications package.