### PR TITLE
iOS Use direct invocation for inapp button tapped callback

### DIFF
--- a/CleverTap/Plugins/iOS/CleverTapBinding.m
+++ b/CleverTap/Plugins/iOS/CleverTapBinding.m
@@ -1,4 +1,5 @@
 #import "CleverTapUnityManager.h"
+#import "CleverTapMessageSender.h"
 
 #pragma mark - Utils
 
@@ -130,6 +131,11 @@ char* clevertap_cStringCopy(const char* string) {
 void CleverTap_onCallbackAdded(const char* callbackName) {
     [[CleverTapUnityManager sharedInstance]
      onCallbackAdded:clevertap_stringToNSString(callbackName)];
+}
+
+void CleverTap_setInAppNotificationButtonTappedCallback(InAppNotificationButtonTapped callback) {
+    [[CleverTapMessageSender sharedInstance]
+     setInAppNotificationButtonTappedCallback:callback];
 }
 
 void CleverTap_setDebugLevel(int level) {

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.h
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.h
@@ -3,6 +3,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (*InAppNotificationButtonTapped) (const char *);
+
 @interface CleverTapMessageSender : NSObject
 
 + (instancetype)sharedInstance;
@@ -11,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)flushBuffer:(CleverTapUnityCallbackInfo *)callbackInfo;
 - (void)disableBuffer:(CleverTapUnityCallbackInfo *)callbackInfo;
 - (void)resetAllBuffers;
+
+- (void)setInAppNotificationButtonTappedCallback:(InAppNotificationButtonTapped)callback;
 
 @end
 

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.m
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.m
@@ -7,6 +7,7 @@ static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
 @interface CleverTapMessageSender()
 
 @property NSDictionary<CleverTapUnityCallbackInfo *, CleverTapMessageBuffer *> *messageBuffers;
+@property (nonatomic) InAppNotificationButtonTapped inAppNotificationButtonTappedCallback;
 
 @end
 
@@ -47,6 +48,15 @@ static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
             [buffer addItem:message];
             return;
         }
+        
+        if (callback == CleverTapUnityCallbackInAppNotificationButtonTapped) {
+            // if direct callback is set call it otherwise fallback to UnitySendMessage
+            if (self.inAppNotificationButtonTappedCallback) {
+                self.inAppNotificationButtonTappedCallback([message UTF8String]);
+                return;
+            }
+        }
+        
         [self sendToUnity:callbackInfo withMessage:message];
     }
 }
@@ -59,6 +69,7 @@ static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
         NSLog(@"Cannot send nil message to Unity. Callback: %@.", callbackInfo.callbackName);
         return;
     }
+    
     UnitySendMessage([kCleverTapGameObjectName UTF8String], [callbackInfo.callbackName UTF8String], [message UTF8String]);
 }
 
@@ -89,6 +100,10 @@ static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
     @synchronized (self) {
         self.messageBuffers = [self createBuffers:NO];
     }
+}
+
+- (void)setInAppNotificationButtonTappedCallback:(InAppNotificationButtonTapped)callback {
+    _inAppNotificationButtonTappedCallback = callback;
 }
 
 @end

--- a/CleverTap/Runtime/IOS/IOSCallbackHandler.cs
+++ b/CleverTap/Runtime/IOS/IOSCallbackHandler.cs
@@ -9,6 +9,8 @@ namespace CleverTapSDK.IOS {
         {
             IOSDllImport.CleverTap_onCallbackAdded(callbackMethod.Method.Name);
         }
+
+        internal delegate void InAppNotificationButtonTapped(string customData);
     }
 }
 #endif

--- a/CleverTap/Runtime/IOS/IOSDllImport.cs
+++ b/CleverTap/Runtime/IOS/IOSDllImport.cs
@@ -1,6 +1,6 @@
 ﻿#if UNITY_IOS
 using System.Runtime.InteropServices;
-using CleverTapSDK.IOS;
+using static CleverTapSDK.IOS.IOSCallbackHandler;
 
 namespace CleverTapSDK.IOS {
     internal static class IOSDllImport {
@@ -9,6 +9,9 @@ namespace CleverTapSDK.IOS {
 
         [DllImport("__Internal")]
         internal static extern void CleverTap_onCallbackAdded(string name);
+
+        [DllImport("__Internal")]
+        internal static extern byte CleverTap_setInAppNotificationButtonTappedCallback(InAppNotificationButtonTapped callback);
 
         [DllImport("__Internal")]
         internal static extern void CleverTap_launchWithCredentials(string accountID, string token);


### PR DESCRIPTION
## Overview
Call the `CleverTapUnityCallbackInAppNotificationButtonTapped` callback directly using `MonoPInvokeCallback` instead of `UnitySendMessage`. 
Fallback to `UnitySendMessage` if the delegate is not set.