### PR TITLE
Deprecate product config and feature flags

### DIFF
--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityCallback.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityCallback.java
@@ -19,9 +19,13 @@ public enum CleverTapUnityCallback {
     CLEVERTAP_ON_INBOX_ITEM_CLICKED("CleverTapInboxItemClicked"),
     CLEVERTAP_ON_INAPP_BUTTON_CLICKED("CleverTapInAppNotificationButtonTapped", true, Mode.DIRECT_CALLBACK),
     CLEVERTAP_DISPLAY_UNITS_UPDATED("CleverTapNativeDisplayUnitsUpdated", true),
+    @Deprecated
     CLEVERTAP_FEATURE_FLAG_UPDATED("CleverTapFeatureFlagsUpdated", true),
+    @Deprecated
     CLEVERTAP_PRODUCT_CONFIG_INITIALIZED("CleverTapProductConfigInitialized", true),
+    @Deprecated
     CLEVERTAP_PRODUCT_CONFIG_FETCHED("CleverTapProductConfigFetched"),
+    @Deprecated
     CLEVERTAP_PRODUCT_CONFIG_ACTIVATED("CleverTapProductConfigActivated"),
     CLEVERTAP_INIT_CLEVERTAP_ID_CALLBACK("CleverTapInitCleverTapIdCallback"),
     CLEVERTAP_VARIABLES_CHANGED("CleverTapVariablesChanged", true),

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityCallbackHandler.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityCallbackHandler.java
@@ -335,6 +335,7 @@ class CleverTapUnityCallbackHandler implements SyncListener, InAppNotificationLi
 
     //Feature Flag Listener
     @Override
+    @Deprecated
     public void featureFlagsUpdated() {
         final String message = "CleverTap App Feature Flags Updated";
         sendToUnity(CLEVERTAP_FEATURE_FLAG_UPDATED, message);
@@ -342,18 +343,21 @@ class CleverTapUnityCallbackHandler implements SyncListener, InAppNotificationLi
 
     //Product Config Listener
     @Override
+    @Deprecated
     public void onInit() {
         final String message = "CleverTap App Product Config Initialized";
         sendToUnity(CLEVERTAP_PRODUCT_CONFIG_INITIALIZED, message);
     }
 
     @Override
+    @Deprecated
     public void onFetched() {
         final String message = "CleverTap App Product Config Fetched";
         sendToUnity(CLEVERTAP_PRODUCT_CONFIG_FETCHED, message);
     }
 
     @Override
+    @Deprecated
     public void onActivated() {
         final String message = "CleverTap App Product Config Activated";
         sendToUnity(CLEVERTAP_PRODUCT_CONFIG_ACTIVATED, message);

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
@@ -841,64 +841,73 @@ public class CleverTapUnityPlugin {
     }
 
     //Feature Flags
-    public Boolean isFeatureFlagInitialized() {
-        return clevertap.featureFlag().isInitialized();
-    }
-
-    public void fetchFeatureFlags() {
-        clevertap.featureFlag().fetchFeatureFlags();
-    }
-
+    @Deprecated
     public Boolean getFeatureFlag(String key, Boolean defaultValue) {
         return clevertap.featureFlag().get(key, defaultValue);
     }
 
     //Product Config
-    public Boolean isProductConfigInitialized() {
-        return clevertap.productConfig().isInitialized();
+    @Deprecated
+    public void setProductConfigMapDefaults(String jsonMap) {
+        Map<String,Object> map = JsonConverter.fromJsonWithConvertedDateValues(jsonMap);
+        if (map == null) {
+            return;
+        }
+        clevertap.productConfig().setDefaults(new HashMap<>(map));
     }
 
-    public void setMapDefaults(HashMap<String, Object> map) {
-        clevertap.productConfig().setDefaults(map);
+    @Deprecated
+    public void setProductConfigMinimumFetchInterval(long fetchIntervalSeconds) {
+        clevertap.productConfig().setMinimumFetchIntervalInSeconds(fetchIntervalSeconds);
     }
 
-    public void fetch() {
+    @Deprecated
+    public void fetchProductConfig() {
         clevertap.productConfig().fetch();
     }
 
-    public void fetch(long minimumIntervalInSeconds) {
+    @Deprecated
+    public void fetchProductConfigWithMinimalInterval(long minimumIntervalInSeconds) {
         clevertap.productConfig().fetch(minimumIntervalInSeconds);
     }
 
-    public void fetchAndActivate() {
+    @Deprecated
+    public void fetchAndActivateProductConfig() {
         clevertap.productConfig().fetchAndActivate();
     }
 
-    public void activate() {
+    @Deprecated
+    public void activateProductConfig() {
         clevertap.productConfig().activate();
     }
 
-    public String getString(String key) {
+    @Deprecated
+    public String getProductConfigString(String key) {
         return clevertap.productConfig().getString(key);
     }
 
-    public Boolean getBoolean(String key) {
+    @Deprecated
+    public Boolean getProductConfigBoolean(String key) {
         return clevertap.productConfig().getBoolean(key);
     }
 
-    public long getLong(String key) {
+    @Deprecated
+    public Long getProductConfigLong(String key) {
         return clevertap.productConfig().getLong(key);
     }
 
-    public Double getDouble(String key) {
+    @Deprecated
+    public Double getProductConfigDouble(String key) {
         return clevertap.productConfig().getDouble(key);
     }
 
+    @Deprecated
     public void productConfigReset() {
         clevertap.productConfig().reset();
     }
 
-    public long getLastFetchTimeStampInMillis() {
+    @Deprecated
+    public long getProductConfigLastFetchTimeStampInMillis() {
         return clevertap.productConfig().getLastFetchTimeStampInMillis();
     }
 

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
@@ -849,7 +849,7 @@ public class CleverTapUnityPlugin {
     //Product Config
     @Deprecated
     public void setProductConfigMapDefaults(String jsonMap) {
-        Map<String,Object> map = JsonConverter.fromJsonWithConvertedDateValues(jsonMap);
+        Map<String, Object> map = JsonConverter.fromJsonWithConvertedDateValues(jsonMap);
         if (map == null) {
             return;
         }
@@ -887,18 +887,21 @@ public class CleverTapUnityPlugin {
     }
 
     @Deprecated
-    public Boolean getProductConfigBoolean(String key) {
-        return clevertap.productConfig().getBoolean(key);
+    public String getProductConfigBoolean(String key) {
+        Boolean config = clevertap.productConfig().getBoolean(key);
+        return config == null ? null : config.toString();
     }
 
     @Deprecated
-    public Long getProductConfigLong(String key) {
-        return clevertap.productConfig().getLong(key);
+    public String getProductConfigLong(String key) {
+        Long config = clevertap.productConfig().getLong(key);
+        return config == null ? null : config.toString();
     }
 
     @Deprecated
-    public Double getProductConfigDouble(String key) {
-        return clevertap.productConfig().getDouble(key);
+    public String getProductConfigDouble(String key) {
+        Double config = clevertap.productConfig().getDouble(key);
+        return config == null ? null : config.toString();
     }
 
     @Deprecated

--- a/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
+++ b/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
@@ -468,6 +468,89 @@ namespace CleverTapSDK.Android {
         {
             return CleverTapAndroidJNI.CleverTapJNIInstance.Call<long>("getUserLastVisitTs");
         }
+
+        #region Feature Flags
+
+        [Obsolete]
+        internal override bool GetFeatureFlag(string key, bool defaultValue)
+        {
+            return CleverTapAndroidJNI.CleverTapJNIInstance.Call<bool>("getFeatureFlag", key, defaultValue);
+        }
+        #endregion
+        #region Product Config
+
+        [Obsolete]
+        internal override void SetProductConfigDefaults(Dictionary<string, object> defaults)
+        {
+            CleverTapAndroidJNI.CleverTapJNIInstance.Call("setProductConfigMapDefaults", Json.Serialize(defaults.ConvertDateObjects()));
+        }
+
+        [Obsolete]
+        internal override void SetProductConfigMinimumFetchInterval(double minimumFetchInterval)
+        {
+            CleverTapAndroidJNI.CleverTapJNIInstance.Call("setProductConfigMinimumFetchInterval", (long) minimumFetchInterval);
+        }
+
+        [Obsolete]
+        internal override void ResetProductConfig()
+        {
+            CleverTapAndroidJNI.CleverTapJNIInstance.Call("productConfigReset");
+        }
+
+        [Obsolete]
+        internal override void ActivateProductConfig()
+        {
+            CleverTapAndroidJNI.CleverTapJNIInstance.Call("activateProductConfig");
+        }
+
+        [Obsolete]
+        internal override void FetchAndActivateProductConfig()
+        {
+            CleverTapAndroidJNI.CleverTapJNIInstance.Call("fetchAndActivateProductConfig");
+        }
+
+               [Obsolete]
+        internal override void FetchProductConfig()
+        {
+            CleverTapAndroidJNI.CleverTapJNIInstance.Call("fetchProductConfig");
+        }
+
+        [Obsolete]
+        internal override void FetchProductConfigWithMinimumInterval(double minimumInterval)
+        {
+            CleverTapAndroidJNI.CleverTapJNIInstance.Call("fetchProductConfigWithMinimalInterval", (long) minimumInterval);
+        }
+
+        [Obsolete]
+        internal override double GetProductConfigLastFetchTimeStamp()
+        {
+            return CleverTapAndroidJNI.CleverTapJNIInstance.Call<long>("getProductConfigLastFetchTimeStampInMillis");    
+        }
+
+        [Obsolete]
+        internal override string GetProductConfigString(string key)
+        {
+            return CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getProductConfigString", key);
+        }
+
+        [Obsolete]
+        internal override bool? GetProductConfigBoolean(string key)
+        {
+            return CleverTapAndroidJNI.CleverTapJNIInstance.Call<bool?>("getProductConfigBoolean", key);
+        }
+
+        [Obsolete]
+        internal override long? GetProductConfigLong(string key)
+        {
+            return CleverTapAndroidJNI.CleverTapJNIInstance.Call<long?>("getProductConfigLong", key);
+        }
+
+        [Obsolete]
+        internal override double? GetProductConfigDouble(string key)
+        {
+            return CleverTapAndroidJNI.CleverTapJNIInstance.Call<double?>("getProductConfigDouble", key);
+        }
+        #endregion
     }
 }
 #endif

--- a/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
+++ b/CleverTap/Runtime/Android/AndroidPlatformBinding.cs
@@ -536,19 +536,22 @@ namespace CleverTapSDK.Android {
         [Obsolete]
         internal override bool? GetProductConfigBoolean(string key)
         {
-            return CleverTapAndroidJNI.CleverTapJNIInstance.Call<bool?>("getProductConfigBoolean", key);
+            var stringValue = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getProductConfigBoolean", key);
+            return bool.TryParse(stringValue, out var result) ? result : null;
         }
 
         [Obsolete]
         internal override long? GetProductConfigLong(string key)
         {
-            return CleverTapAndroidJNI.CleverTapJNIInstance.Call<long?>("getProductConfigLong", key);
+            var stringValue = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getProductConfigLong", key);
+            return long.TryParse(stringValue, out var result) ? result : null;
         }
 
         [Obsolete]
         internal override double? GetProductConfigDouble(string key)
         {
-            return CleverTapAndroidJNI.CleverTapJNIInstance.Call<double?>("getProductConfigDouble", key);
+            var stringValue = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getProductConfigDouble", key);
+            return double.TryParse(stringValue, out var result) ? result : null;
         }
         #endregion
     }

--- a/CleverTap/Runtime/CleverTap.cs
+++ b/CleverTap/Runtime/CleverTap.cs
@@ -110,16 +110,19 @@ namespace CleverTapSDK {
             remove => cleverTapCallbackHandler.OnCleverTapNativeDisplayUnitsUpdated -= value;
         }
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static event CleverTapCallbackWithMessageDelegate OnCleverTapProductConfigFetched {
             add => cleverTapCallbackHandler.OnCleverTapProductConfigFetched += value;
             remove => cleverTapCallbackHandler.OnCleverTapProductConfigFetched -= value;
         }
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static event CleverTapCallbackWithMessageDelegate OnCleverTapProductConfigActivated {
             add => cleverTapCallbackHandler.OnCleverTapProductConfigActivated += value;
             remove => cleverTapCallbackHandler.OnCleverTapProductConfigActivated -= value;
         }
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static event CleverTapCallbackWithMessageDelegate OnCleverTapProductConfigInitialized {
             add => cleverTapCallbackHandler.OnCleverTapProductConfigInitialized += value;
             remove => cleverTapCallbackHandler.OnCleverTapProductConfigInitialized -= value;
@@ -171,6 +174,7 @@ namespace CleverTapSDK {
 
         #region Methods - CleverTap Platform Bindings
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static void ActivateProductConfig() =>
             cleverTapBinding.ActivateProductConfig();
 
@@ -232,12 +236,15 @@ namespace CleverTapSDK {
         public static int EventGetOccurrences(string eventName) =>
             cleverTapBinding.EventGetOccurrences(eventName);
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static void FetchAndActivateProductConfig() =>
             cleverTapBinding.FetchAndActivateProductConfig();
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static void FetchProductConfig() =>
             cleverTapBinding.FetchProductConfig();
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static void FetchProductConfigWithMinimumInterval(double minimumInterval) =>
             cleverTapBinding.FetchProductConfigWithMinimumInterval(minimumInterval);
 
@@ -256,6 +263,7 @@ namespace CleverTapSDK {
         public static JSONClass GetDisplayUnitForID(string unitID) =>
             cleverTapBinding.GetDisplayUnitForID(unitID);
 
+        [Obsolete("Feature flags are deprecated, use variables instead.")]
         public static bool GetFeatureFlag(string key, bool defaultValue) =>
             cleverTapBinding.GetFeatureFlag(key, defaultValue);
 
@@ -271,11 +279,31 @@ namespace CleverTapSDK {
         public static int GetInboxMessageUnreadCount() =>
             cleverTapBinding.GetInboxMessageUnreadCount();
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static double GetProductConfigLastFetchTimeStamp() =>
             cleverTapBinding.GetProductConfigLastFetchTimeStamp();
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static JSONClass GetProductConfigValueFor(string key) =>
             cleverTapBinding.GetProductConfigValueFor(key);
+
+        [Obsolete("Product config is deprecated, use variables instead.")]
+        public static string GetProductConfigString(string key) =>
+            cleverTapBinding.GetProductConfigString(key);
+
+        [Obsolete("Product config is deprecated, use variables instead.")]
+        public static bool? GetProductConfigBoolean(string key) =>
+            cleverTapBinding.GetProductConfigBoolean(key);
+        
+
+        [Obsolete("Product config is deprecated, use variables instead.")]
+        public static long? GetProductConfigLong(string key) =>
+            cleverTapBinding.GetProductConfigLong(key);
+        
+
+        [Obsolete("Product config is deprecated, use variables instead.")]
+        public static double? GetProductConfigDouble(string key) =>
+            cleverTapBinding.GetProductConfigDouble(key);    
 
         public static JSONArray GetUnreadInboxMessages() =>
             cleverTapBinding.GetUnreadInboxMessages();
@@ -391,6 +419,7 @@ namespace CleverTapSDK {
         public static void RegisterPush() =>
             cleverTapBinding.RegisterPush();
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static void ResetProductConfig() =>
             cleverTapBinding.ResetProductConfig();
 
@@ -418,12 +447,15 @@ namespace CleverTapSDK {
         public static void SetOptOut(bool enabled) =>
             cleverTapBinding.SetOptOut(enabled);
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static void SetProductConfigDefaults(Dictionary<string, object> defaults) =>
             cleverTapBinding.SetProductConfigDefaults(defaults);
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static void SetProductConfigDefaultsFromPlistFileName(string fileName) =>
             cleverTapBinding.SetProductConfigDefaultsFromPlistFileName(fileName);
 
+        [Obsolete("Product config is deprecated, use variables instead.")]
         public static void SetProductConfigMinimumFetchInterval(double minimumFetchInterval) =>
             cleverTapBinding.SetProductConfigMinimumFetchInterval(minimumFetchInterval);
 

--- a/CleverTap/Runtime/CleverTap.cs
+++ b/CleverTap/Runtime/CleverTap.cs
@@ -283,24 +283,52 @@ namespace CleverTapSDK {
         public static double GetProductConfigLastFetchTimeStamp() =>
             cleverTapBinding.GetProductConfigLastFetchTimeStamp();
 
+        /// <summary>
+        /// Get the value of a product config key. This method only works on iOS Platform.
+        /// Use <see cref="GetProductConfigString(string)"/>, <see cref="GetProductConfigBoolean(string)"/>,
+        /// <see cref="GetProductConfigLong(string)"/>, or <see cref="GetProductConfigDouble(string)"/>
+        /// for Android Platform.
+        /// </summary>
+        /// <param name="key"> The key for the product config</param>
+        /// <returns>The value for the key as JSONClass</returns>
         [Obsolete("Product config is deprecated, use variables instead.")]
         public static JSONClass GetProductConfigValueFor(string key) =>
             cleverTapBinding.GetProductConfigValueFor(key);
 
+        /// <summary>
+        /// Get the value of a string product config key. This method only works on Android Platform.
+        /// Use <see cref="GetProductConfigValueFor(string)"/> for iOS Platform.
+        /// </summary>
+        /// <param name="key"> The key for the product config</param>
         [Obsolete("Product config is deprecated, use variables instead.")]
         public static string GetProductConfigString(string key) =>
             cleverTapBinding.GetProductConfigString(key);
 
+        /// <summary>
+        /// Get the value of a bool product config key. This method only works on Android Platform.
+        /// Use <see cref="GetProductConfigValueFor(string)"/> for iOS Platform.
+        /// </summary>
+        /// <param name="key"> The key for the product config</param>
         [Obsolete("Product config is deprecated, use variables instead.")]
         public static bool? GetProductConfigBoolean(string key) =>
             cleverTapBinding.GetProductConfigBoolean(key);
         
 
+        /// <summary>
+        /// Get the value of a long product config key. This method only works on Android Platform.
+        /// Use <see cref="GetProductConfigValueFor(string)"/> for iOS Platform.
+        /// </summary>
+        /// <param name="key"> The key for the product config</param>
         [Obsolete("Product config is deprecated, use variables instead.")]
         public static long? GetProductConfigLong(string key) =>
             cleverTapBinding.GetProductConfigLong(key);
         
 
+        /// <summary>
+        /// Get the value of a long product config key. This method only works on Android Platform.
+        /// Use <see cref="GetProductConfigValueFor(string)"/> for iOS Platform.
+        /// </summary>
+        /// <param name="key"> The key for the product config</param>
         [Obsolete("Product config is deprecated, use variables instead.")]
         public static double? GetProductConfigDouble(string key) =>
             cleverTapBinding.GetProductConfigDouble(key);    

--- a/CleverTap/Runtime/Common/CleverTapCallbackHandler.cs
+++ b/CleverTap/Runtime/Common/CleverTapCallbackHandler.cs
@@ -331,7 +331,10 @@ namespace CleverTapSDK.Common {
             }
         }
 
+        [Obsolete]
         private CleverTapCallbackWithMessageDelegate _OnCleverTapProductConfigFetched;
+
+        [Obsolete]
         public event CleverTapCallbackWithMessageDelegate OnCleverTapProductConfigFetched
         {
             add
@@ -351,7 +354,10 @@ namespace CleverTapSDK.Common {
             }
         }
 
+        [Obsolete]
         private CleverTapCallbackWithMessageDelegate _OnCleverTapProductConfigActivated;
+
+        [Obsolete]
         public event CleverTapCallbackWithMessageDelegate OnCleverTapProductConfigActivated
         {
             add
@@ -371,7 +377,10 @@ namespace CleverTapSDK.Common {
             }
         }
 
+        [Obsolete]
         private CleverTapCallbackWithMessageDelegate _OnCleverTapProductConfigInitialized;
+
+        [Obsolete]
         public event CleverTapCallbackWithMessageDelegate OnCleverTapProductConfigInitialized
         {
             add

--- a/CleverTap/Runtime/Common/CleverTapPlatformBindings.cs
+++ b/CleverTap/Runtime/Common/CleverTapPlatformBindings.cs
@@ -119,7 +119,7 @@ namespace CleverTapSDK.Common {
             return new JSONClass();
         }
 
-        [Obsolete("Feature flags are deprecated, use variables instead.")]
+        [Obsolete]
         internal virtual bool GetFeatureFlag(string key, bool defaultValue) {
             // Validate if this is ok?
             return defaultValue;

--- a/CleverTap/Runtime/Common/CleverTapPlatformBindings.cs
+++ b/CleverTap/Runtime/Common/CleverTapPlatformBindings.cs
@@ -20,6 +20,7 @@ namespace CleverTapSDK.Common {
 
         #region Default - Platform Bindings
 
+        [Obsolete]
         internal virtual void ActivateProductConfig() {
         }
 
@@ -85,12 +86,15 @@ namespace CleverTapSDK.Common {
             return -1;
         }
 
+        [Obsolete]
         internal virtual void FetchAndActivateProductConfig() {
         }
 
+        [Obsolete]
         internal virtual void FetchProductConfig() {
         }
 
+        [Obsolete]
         internal virtual void FetchProductConfigWithMinimumInterval(double minimumInterval) {
         }
 
@@ -115,6 +119,7 @@ namespace CleverTapSDK.Common {
             return new JSONClass();
         }
 
+        [Obsolete("Feature flags are deprecated, use variables instead.")]
         internal virtual bool GetFeatureFlag(string key, bool defaultValue) {
             // Validate if this is ok?
             return defaultValue;
@@ -137,12 +142,38 @@ namespace CleverTapSDK.Common {
             return -1;
         }
 
+        [Obsolete]
         internal virtual double GetProductConfigLastFetchTimeStamp() {
             return -1;
         }
 
+        [Obsolete]
         internal virtual JSONClass GetProductConfigValueFor(string key) {
             return new JSONClass();
+        }
+
+        [Obsolete]
+        internal virtual string GetProductConfigString(string key)
+        {
+            return null;
+        }
+
+        [Obsolete]
+        internal virtual bool? GetProductConfigBoolean(string key)
+        {
+            return null;
+        }
+
+        [Obsolete]
+        internal virtual long? GetProductConfigLong(string key)
+        {
+            return null;
+        }
+
+        [Obsolete]
+        internal virtual double? GetProductConfigDouble(string key)
+        {
+            return null;
         }
 
         internal virtual JSONArray GetUnreadInboxMessages() {
@@ -270,6 +301,7 @@ namespace CleverTapSDK.Common {
         internal virtual void RegisterPush() {
         }
 
+        [Obsolete]
         internal virtual void ResetProductConfig() {
         }
 
@@ -299,12 +331,15 @@ namespace CleverTapSDK.Common {
         internal virtual void SetOptOut(bool enabled) {
         }
 
+        [Obsolete]
         internal virtual void SetProductConfigDefaults(Dictionary<string, object> defaults) {
         }
 
+        [Obsolete]
         internal virtual void SetProductConfigDefaultsFromPlistFileName(string fileName) {
         }
 
+        [Obsolete]
         internal virtual void SetProductConfigMinimumFetchInterval(double minimumFetchInterval) {
         }
 

--- a/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
+++ b/CleverTap/Runtime/IOS/IOSPlatformBinding.cs
@@ -34,6 +34,7 @@ namespace CleverTapSDK.IOS
             staticCallbackHandler.CleverTapInAppNotificationButtonTapped(customData);
         }
 
+        [Obsolete]
         internal override void ActivateProductConfig() {
             IOSDllImport.CleverTap_activateProductConfig();
         }
@@ -94,14 +95,17 @@ namespace CleverTapSDK.IOS
             return IOSDllImport.CleverTap_eventGetOccurrences(eventName);
         }
 
+        [Obsolete]
         internal override void FetchAndActivateProductConfig() {
             IOSDllImport.CleverTap_fetchAndActivateProductConfig();
         }
 
+        [Obsolete]
         internal override void FetchProductConfig() {
             IOSDllImport.CleverTap_fetchProductConfig();
         }
 
+        [Obsolete]
         internal override void FetchProductConfigWithMinimumInterval(double minimumInterval) {
             IOSDllImport.CleverTap_fetchProductConfigWithMinimumInterval(minimumInterval);
         }
@@ -206,10 +210,12 @@ namespace CleverTapSDK.IOS
             return IOSDllImport.CleverTap_getInboxMessageUnreadCount();
         }
 
+        [Obsolete]
         internal override double GetProductConfigLastFetchTimeStamp() {
             return IOSDllImport.CleverTap_getProductConfigLastFetchTimeStamp();
         }
 
+        [Obsolete]
         internal override JSONClass GetProductConfigValueFor(string key) {
             string jsonString = IOSDllImport.CleverTap_getProductConfigValueFor(key);
             JSONClass json;
@@ -407,6 +413,7 @@ namespace CleverTapSDK.IOS
             IOSDllImport.CleverTap_registerPush();
         }
 
+        [Obsolete]
         internal override void ResetProductConfig() {
             IOSDllImport.CleverTap_resetProductConfig();
         }
@@ -451,15 +458,18 @@ namespace CleverTapSDK.IOS
             IOSDllImport.CleverTap_setOptOut(enabled);
         }
 
+        [Obsolete]
         internal override void SetProductConfigDefaults(Dictionary<string, object> defaults) {
             var defaultsString = Json.Serialize(defaults);
             IOSDllImport.CleverTap_setProductConfigDefaults(defaultsString);
         }
 
+        [Obsolete]
         internal override void SetProductConfigDefaultsFromPlistFileName(string fileName) {
             IOSDllImport.CleverTap_setProductConfigDefaultsFromPlistFileName(fileName);
         }
 
+        [Obsolete]
         internal override void SetProductConfigMinimumFetchInterval(double minimumFetchInterval) {
             IOSDllImport.CleverTap_setProductConfigMinimumFetchInterval(minimumFetchInterval);
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation**
	- Marked multiple methods and constants related to feature flags and product configuration as deprecated across Android and iOS platforms
	- Indicates a transition away from current implementation of product configuration and feature flag management

- **Changes**
	- Removed several methods for initializing, fetching, and managing feature flags and product configurations
	- Added obsolete warnings to prevent future use of deprecated methods
	- Introduced new method naming conventions for product configuration interactions

- **Impact**
	- Developers should expect to update their code to use new methods or alternative approaches for feature flag and product configuration management
	- Existing functionality remains unchanged, but usage of deprecated methods will trigger compiler warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->