### PR TITLE
iOS fixes and improvements

### DIFF
--- a/CleverTap/Plugins/iOS/CleverTapBinding.m
+++ b/CleverTap/Plugins/iOS/CleverTapBinding.m
@@ -69,7 +69,7 @@ NSMutableArray* clevertap_NSArrayFromJsonString(const char* jsonString) {
     return arr;
 }
 
-[[deprecated("Used by deprecated methods only.")]]
+__attribute__((deprecated("Used by deprecated methods only.")))
 NSMutableDictionary* clevertap_eventDetailToDict(CleverTapEventDetail* detail) {
     
     NSMutableDictionary *_dict = [NSMutableDictionary new];
@@ -339,22 +339,22 @@ void CleverTap_recordChargedEventWithDetailsAndItems(const char* chargeDetails, 
     [[CleverTapUnityManager sharedInstance] recordChargedEventWithDetails:details andItems:_items];
 }
 
-[[deprecated("Deprecated, use getUserEventLog instead")]]
+__attribute__((deprecated("Deprecated, use getUserEventLog instead")))
 int CleverTap_eventGetFirstTime(const char* eventName) {
     return [[CleverTapUnityManager sharedInstance] eventGetFirstTime:clevertap_stringToNSString(eventName)];
 }
 
-[[deprecated("Deprecated, use getUserEventLog instead")]]
+__attribute__((deprecated("Deprecated, use getUserEventLog instead")))
 int CleverTap_eventGetLastTime(const char* eventName) {
     return [[CleverTapUnityManager sharedInstance] eventGetLastTime:clevertap_stringToNSString(eventName)];
 }
 
-[[deprecated("Deprecated, use getUserEventLogCount instead")]]
+__attribute__((deprecated("Deprecated, use getUserEventLogCount instead")))
 int CleverTap_eventGetOccurrences(const char* eventName) {
     return [[CleverTapUnityManager sharedInstance] eventGetOccurrences:clevertap_stringToNSString(eventName)];
 }
 
-[[deprecated("Deprecated, use getUserEventLogHistory instead")]]
+__attribute__((deprecated("Deprecated, use getUserEventLogHistory instead")))
 char* CleverTap_userGetEventHistory() {
     NSDictionary *history = [[CleverTapUnityManager sharedInstance] userGetEventHistory];
     
@@ -393,7 +393,7 @@ int CleverTap_sessionGetTimeElapsed() {
     return [[CleverTapUnityManager sharedInstance] sessionGetTimeElapsed];
 }
 
-[[deprecated("Deprecated, use getUserEventLog instead")]]
+__attribute__((deprecated("Deprecated, use getUserEventLog instead")))
 char* CleverTap_eventGetDetail(const char* eventName) {
     CleverTapEventDetail *detail = [[CleverTapUnityManager sharedInstance] eventGetDetail:clevertap_stringToNSString(eventName)];
     
@@ -408,7 +408,7 @@ char* CleverTap_eventGetDetail(const char* eventName) {
     return clevertap_cStringCopy([jsonString UTF8String]);
 }
 
-[[deprecated("Deprecated, use getUserAppLaunchCount instead")]]
+__attribute__((deprecated("Deprecated, use getUserAppLaunchCount instead")))
 int CleverTap_userGetTotalVisits() {
     return [[CleverTapUnityManager sharedInstance] userGetTotalVisits];
 }
@@ -417,11 +417,10 @@ int CleverTap_userGetScreenCount() {
     return [[CleverTapUnityManager sharedInstance] userGetScreenCount];
 }
 
-[[deprecated("Deprecated, use getUserLastVisitTs instead")]]
+__attribute__((deprecated("Deprecated, use getUserLastVisitTs instead")))
 int CleverTap_userGetPreviousVisitTime() {
     return [[CleverTapUnityManager sharedInstance] userGetPreviousVisitTime];
 }
-
 
 #pragma mark - Push Notifications
 

--- a/CleverTap/Plugins/iOS/CleverTapMessageBuffer.m
+++ b/CleverTap/Plugins/iOS/CleverTapMessageBuffer.m
@@ -1,32 +1,43 @@
 #import "CleverTapMessageBuffer.h"
 
+@interface CleverTapMessageBuffer ()
+@property (nonatomic, strong, readonly) NSObject *lock;
+@end
+
 @implementation CleverTapMessageBuffer
 
 - (instancetype)initWithEnabled:(BOOL)isEnabled {
     if (self = [super init]) {
-        self.isEnabled = isEnabled;
-        self.items = [NSMutableArray array];
+        _isEnabled = isEnabled;
+        _items = [NSMutableArray array];
+        _lock = [[NSObject alloc] init];
     }
     return self;
 }
 
 - (void)addItem:(NSString *)item {
-    if (item) {
-        [self.items addObject:item];
+    @synchronized(self.lock) {
+        if (item) {
+            [self.items addObject:item];
+        }
     }
 }
 
 - (nullable NSString *)popItem {
-    if (self.items.count > 0) {
-        NSString *last = [self.items lastObject];
-        [self.items removeLastObject];
-        return last;
+    @synchronized(self.lock) {
+        if (self.items.count > 0) {
+            NSString *last = [self.items lastObject];
+            [self.items removeLastObject];
+            return last;
+        }
+        return nil;
     }
-    return nil;
 }
 
 - (NSUInteger)count {
-    return self.items.count;
+    @synchronized(self.lock) {
+        return self.items.count;
+    }
 }
 
 @end

--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.m
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.m
@@ -64,6 +64,7 @@ static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
 - (void)sendToUnity:(CleverTapUnityCallbackInfo *)callbackInfo withMessage:(NSString *)message {
     if (!callbackInfo) {
         NSLog(@"Cannot send message for nil callback.");
+        return;
     }
     if (!message) {
         NSLog(@"Cannot send nil message to Unity. Callback: %@.", callbackInfo.callbackName);

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -1071,7 +1071,7 @@ NSDictionary *cleverTap_convertDateValues(NSDictionary *dictionary) {
 - (int16_t)customTemplateGetShortArg:(NSString *)templateName named:(NSString *)argumentName {
     CTTemplateContext *context = [self contextNamed:templateName];
     if (context) {
-        return [[context numberNamed:argumentName] charValue];
+        return (int16_t)[[context numberNamed:argumentName] charValue];
     }
     
     return 0;


### PR DESCRIPTION
## Fixes
Fix Xcode 14 and Xcode 15 compilation issues:
```
Call to undeclared function 'deprecated'; ISO C99 and later do not support implicit function declarations
```
`[[deprecated(...)]])` is a C++/C11 attribute, but .m files in Objective-C are typically compiled as C99 or later, which does not support this syntax.

Return if nil callback info is sent to `CleverTapMessageSender`.

Cast `customTemplateGetShortArg` result to `int16_t`.

## Improvements
Synchronize the `CleverTapMessageBuffer`.