### PR TITLE
Fix Android Gradle project build

### DIFF
--- a/CleverTap/Editor/AndroidProjectPostProcessor.cs
+++ b/CleverTap/Editor/AndroidProjectPostProcessor.cs
@@ -2,27 +2,20 @@
 using System.IO;
 using System.Xml;
 using UnityEditor;
-using UnityEditor.Callbacks;
+using UnityEditor.Android;
 using UnityEngine;
 
 namespace CleverTapSDK.Private
 {
-    public class AndroidPostBuildProcessor
+    public class AndroidProjectPostProcessor: IPostGenerateGradleAndroidProject
 	{
         private static readonly string ANDROID_XML_NS_URI = "http://schemas.android.com/apk/res/android";
 
-        [PostProcessBuild(99)]
-        public static void OnPostprocessBuild(BuildTarget target, string path)
-        {
-            if (target == BuildTarget.Android)
-            {
-                AndroidPostProcess(path);
-            }
-        }
+        public int callbackOrder => 99;
 
-        private static void AndroidPostProcess(string path)
+        public void OnPostGenerateGradleAndroidProject(string path)
         {
-            string androidProjectPath = path + "/unityLibrary/clevertap-android-wrapper.androidlib";
+            string androidProjectPath = path + "/clevertap-android-wrapper.androidlib";
 
             // copy assets to the android project
             EditorUtils.DirectoryCopy(Path.Combine(Application.dataPath, EditorUtils.CLEVERTAP_ASSETS_FOLDER),

--- a/CleverTap/Editor/AndroidProjectPostProcessor.cs.meta
+++ b/CleverTap/Editor/AndroidProjectPostProcessor.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 07c93233c64ca40879b99568f4d862f0
+guid: c7ae25f6034ee4091ba1d8719ed1de9f
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ You can install the CleverTap Unity SDK using the `.unitypackage` Unity package 
 
 1. Download the latest version of the CleverTap Unity package. Import the `.unitypackage` into your Unity Project. **Go to Assets** > **Import Package** > **Custom Package**. 
 2. Add the **PlayServiceResolver** and the **ExternalDependencyManager** folders. These folders will install the **EDM4U** plugin, which automatically adds all the Android and iOS dependencies when building your project.
-3. Ensure that the scripts inside the `Editor` folder are added. The `AndroidPostImport` script sets up `clevertap-android-wrapper` library for Android. IOS/Android `PostBuildProcessor` scripts helps iOS and Android setup.
+3. Ensure that the scripts inside the `Editor` folder are added. The `AndroidPostImport` script sets up `clevertap-android-wrapper` library for Android. `IOSPostBuildProcessor` and `AndroidProjectPostProcessor` scripts helps iOS and Android setup.
 
 ### Import the CleverTap Unity Package as a Local Dependency
 


### PR DESCRIPTION
Use IPostGenerateGradleAndroidProject instead of PostProcessBuild to include CleverTap assets to the project