### PR TITLE
iOS CleverTapUnityCallbackInfo and CleverTapUnityCallback improvements

### DIFF
--- a/CleverTap/Plugins/iOS/CleverTapMessageSender.m
+++ b/CleverTap/Plugins/iOS/CleverTapMessageSender.m
@@ -31,7 +31,7 @@ static NSString * kCleverTapGameObjectName = @"IOSCallbackHandler";
 
 - (NSDictionary<CleverTapUnityCallbackInfo *, CleverTapMessageBuffer *> *)createBuffers:(BOOL)enabled {
     NSMutableDictionary<CleverTapUnityCallbackInfo *, CleverTapMessageBuffer *> *buffers = [NSMutableDictionary dictionary];
-    NSArray *callbackInfos = [CleverTapUnityCallbackInfo callbackInfos];
+    NSArray *callbackInfos = [[CleverTapUnityCallbackInfo callbackInfos] allValues];
     for (CleverTapUnityCallbackInfo *info in callbackInfos) {
         if (info.isBufferable) {
             buffers[info] = [[CleverTapMessageBuffer alloc] initWithEnabled:enabled];

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.h
@@ -42,7 +42,8 @@ typedef NS_ENUM(NSInteger, CleverTapUnityCallback) {
 
 + (nullable CleverTapUnityCallbackInfo *)infoForCallback:(CleverTapUnityCallback)callback;
 + (nullable CleverTapUnityCallbackInfo *)callbackFromName:(NSString *)callbackName;
-+ (NSArray<CleverTapUnityCallbackInfo *> *)callbackInfos;
++ (NSDictionary<NSNumber *, CleverTapUnityCallbackInfo *> *)callbackInfos;
++ (nullable NSNumber *)callbackEnumForName:(NSString *)callbackName;
 
 @end
 

--- a/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityCallbackInfo.mm
@@ -28,62 +28,106 @@
     return [[CleverTapUnityCallbackInfo allocWithZone:zone] initWithName:self.callbackName bufferable:self.isBufferable];
 }
 
-+ (NSArray<CleverTapUnityCallbackInfo *> *)callbackInfos {
-    static NSArray<CleverTapUnityCallbackInfo *> *callbacks = nil;
++ (NSDictionary<NSNumber *, CleverTapUnityCallbackInfo *> *)callbackInfos {
+    static NSDictionary<NSNumber *, CleverTapUnityCallbackInfo *> *callbacks = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        callbacks = @[
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileInitializedCallback" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileUpdatesCallback" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapDeepLinkCallback" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushNotificationTappedWithCustomExtrasCallback" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushOpenedCallback" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationDismissedCallback" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationButtonTapped" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxDidInitializeCallback" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxMessagesDidUpdateCallback" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxCustomExtrasButtonSelect" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxItemClicked" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapNativeDisplayUnitsUpdated" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapFeatureFlagsUpdated" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigInitialized" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigFetched" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigActivated" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesChanged" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariableValueChanged" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesFetched" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppsFetched" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesChangedAndNoDownloadsPending" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariableFileIsReady" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplatePresent" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomFunctionPresent" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplateClose" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapOnPushPermissionResponseCallback" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushNotificationPermissionStatus" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationShowCallback" bufferable:YES],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"OneTimeCleverTapVariablesChanged" bufferable:NO],
-            [[CleverTapUnityCallbackInfo alloc] initWithName:@"OneTimeCleverTapVariablesChangedAndNoDownloadsPending" bufferable:NO]
-        ];
+        callbacks = @{
+            @(CleverTapUnityCallbackProfileInitialized):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileInitializedCallback" bufferable:YES],
+            @(CleverTapUnityCallbackProfileUpdates):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProfileUpdatesCallback" bufferable:NO],
+            @(CleverTapUnityCallbackDeepLink):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapDeepLinkCallback" bufferable:YES],
+            @(CleverTapUnityCallbackPushNotificationTappedWithCustomExtras):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushNotificationTappedWithCustomExtrasCallback" bufferable:YES],
+            @(CleverTapUnityCallbackPushOpened):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushOpenedCallback" bufferable:YES],
+            @(CleverTapUnityCallbackInAppNotificationDismissed):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationDismissedCallback" bufferable:YES],
+            @(CleverTapUnityCallbackInAppNotificationButtonTapped):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationButtonTapped" bufferable:YES],
+            @(CleverTapUnityCallbackInboxDidInitialize):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxDidInitializeCallback" bufferable:YES],
+            @(CleverTapUnityCallbackInboxMessagesDidUpdate):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxMessagesDidUpdateCallback" bufferable:NO],
+            @(CleverTapUnityCallbackInboxCustomExtrasButtonSelect):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxCustomExtrasButtonSelect" bufferable:NO],
+            @(CleverTapUnityCallbackInboxItemClicked):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInboxItemClicked" bufferable:NO],
+            @(CleverTapUnityCallbackNativeDisplayUnitsUpdated):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapNativeDisplayUnitsUpdated" bufferable:YES],
+            @(CleverTapUnityCallbackFeatureFlagsUpdated):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapFeatureFlagsUpdated" bufferable:YES],
+            @(CleverTapUnityCallbackProductConfigInitialized):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigInitialized" bufferable:YES],
+            @(CleverTapUnityCallbackProductConfigFetched):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigFetched" bufferable:NO],
+            @(CleverTapUnityCallbackProductConfigActivated):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapProductConfigActivated" bufferable:NO],
+            @(CleverTapUnityCallbackVariablesChanged):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesChanged" bufferable:NO],
+            @(CleverTapUnityCallbackVariableValueChanged):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariableValueChanged" bufferable:NO],
+            @(CleverTapUnityCallbackVariablesFetched):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesFetched" bufferable:NO],
+            @(CleverTapUnityCallbackInAppsFetched):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppsFetched" bufferable:NO],
+            @(CleverTapUnityCallbackVariablesChangedAndNoDownloadsPending):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariablesChangedAndNoDownloadsPending" bufferable:NO],
+            @(CleverTapUnityCallbackVariableFileIsReady):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapVariableFileIsReady" bufferable:NO],
+            @(CleverTapUnityCallbackCustomTemplatePresent):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplatePresent" bufferable:YES],
+            @(CleverTapUnityCallbackCustomFunctionPresent):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomFunctionPresent" bufferable:YES],
+            @(CleverTapUnityCallbackCustomTemplateClose):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapCustomTemplateClose" bufferable:NO],
+            @(CleverTapUnityCallbackPushPermissionResponseReceived):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapOnPushPermissionResponseCallback" bufferable:YES],
+            @(CleverTapUnityCallbackPushNotificationPermissionStatus):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapPushNotificationPermissionStatus" bufferable:NO],
+            @(CleverTapUnityCallbackInAppNotificationDidShow):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"CleverTapInAppNotificationShowCallback" bufferable:YES],
+            @(CleverTapUnityCallbackOneTimeVariablesChanged):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"OneTimeCleverTapVariablesChanged" bufferable:NO],
+            @(CleverTapUnityCallbackOneTimeVariablesChangedAndNoDownloadsPending):
+                [[CleverTapUnityCallbackInfo alloc] initWithName:@"OneTimeCleverTapVariablesChangedAndNoDownloadsPending" bufferable:NO]
+        };
     });
     return callbacks;
 }
 
++ (NSDictionary<NSString *, NSNumber *> *)namesCallbacks {
+    NSDictionary *callbackInfos = [self callbackInfos];
+    static NSDictionary<NSString *, NSNumber *> *namesCallbacks = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableDictionary<NSString *, NSNumber *> *namesCallbacksMutable = [NSMutableDictionary dictionaryWithCapacity:callbackInfos.count];
+        for (NSNumber *key in callbackInfos) {
+            CleverTapUnityCallbackInfo *info = [callbackInfos objectForKey:key];
+            [namesCallbacksMutable setObject:key forKey:info.callbackName];
+        }
+        namesCallbacks = namesCallbacksMutable;
+    });
+    return namesCallbacks;
+}
+
 + (nullable CleverTapUnityCallbackInfo *)infoForCallback:(CleverTapUnityCallback)callback {
-    NSArray<CleverTapUnityCallbackInfo *> *callbacks = [self callbackInfos];
-    if (callback < callbacks.count) {
-        return callbacks[callback];
+    return [self callbackInfos][@(callback)];
+}
+
++ (nullable CleverTapUnityCallbackInfo *)callbackFromName:(NSString *)callbackName {
+    NSNumber *index = [self callbackEnumForName:callbackName];
+    if (index) {
+        CleverTapUnityCallback callback = (CleverTapUnityCallback)[index integerValue];
+        return [self infoForCallback:(CleverTapUnityCallback)callback];
     }
     return nil;
 }
 
-+ (nullable CleverTapUnityCallbackInfo *)callbackFromName:(NSString *)callbackName {
-    NSArray<CleverTapUnityCallbackInfo *> *callbacks = [self callbackInfos];
-    for (CleverTapUnityCallbackInfo *callback in callbacks) {
-        if ([callback.callbackName isEqualToString:callbackName]) {
-            return callback;
-        }
-    }
-    return nil;
++ (nullable NSNumber *)callbackEnumForName:(NSString *)callbackName {
+    return [self namesCallbacks][callbackName];
 }
 
 @end

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -79,28 +79,31 @@ static BOOL platformDidInit = NO;
 }
 
 - (void)onVariablesCallbackAdded:(NSString *)callbackName callbackId:(int)callbackId {
-    CleverTapUnityCallbackInfo *callback = [CleverTapUnityCallbackInfo callbackFromName:callbackName];
-    if (!callback) {
+    NSNumber *callbackEnum = [CleverTapUnityCallbackInfo callbackEnumForName:callbackName];
+    if (!callbackEnum) {
         NSLog(@"Unsupported callback added: %@", callbackName);
         return;
     }
     
-    if ([callback isEqual:[CleverTapUnityCallbackInfo infoForCallback:CleverTapUnityCallbackVariablesChanged]]) {
-        [self.cleverTap onVariablesChanged:
-             [[CleverTapUnityCallbackHandler sharedInstance] variablesCallback:CleverTapUnityCallbackVariablesChanged callbackId:callbackId]
-        ];
-    }
-    if ([callback isEqual:[CleverTapUnityCallbackInfo infoForCallback:CleverTapUnityCallbackVariablesChangedAndNoDownloadsPending]]) {
-        [self.cleverTap onVariablesChangedAndNoDownloadsPending:[[CleverTapUnityCallbackHandler sharedInstance] variablesCallback:CleverTapUnityCallbackVariablesChangedAndNoDownloadsPending callbackId:callbackId]];
-    }
-    if ([callback isEqual:[CleverTapUnityCallbackInfo infoForCallback:CleverTapUnityCallbackOneTimeVariablesChanged]]) {
-        [self.cleverTap onceVariablesChanged:
-         [[CleverTapUnityCallbackHandler sharedInstance] variablesCallback:CleverTapUnityCallbackOneTimeVariablesChanged callbackId:callbackId]];
-    }
-    if ([callback isEqual:[CleverTapUnityCallbackInfo infoForCallback:CleverTapUnityCallbackOneTimeVariablesChangedAndNoDownloadsPending]]) {
-        [self.cleverTap onceVariablesChangedAndNoDownloadsPending:
-             [[CleverTapUnityCallbackHandler sharedInstance] variablesCallback:CleverTapUnityCallbackOneTimeVariablesChangedAndNoDownloadsPending callbackId:callbackId]
-        ];
+    CleverTapUnityCallback callback = (CleverTapUnityCallback)[callbackEnum integerValue];
+    CleverTapUnityCallbackHandler *handler = [CleverTapUnityCallbackHandler sharedInstance];
+    
+    switch (callback) {
+        case CleverTapUnityCallbackVariablesChanged:
+            [self.cleverTap onVariablesChanged:[handler variablesCallback:CleverTapUnityCallbackVariablesChanged callbackId:callbackId]];
+            break;
+        case CleverTapUnityCallbackVariablesChangedAndNoDownloadsPending:
+            [self.cleverTap onVariablesChangedAndNoDownloadsPending:[handler variablesCallback:CleverTapUnityCallbackVariablesChangedAndNoDownloadsPending callbackId:callbackId]];
+            break;
+        case CleverTapUnityCallbackOneTimeVariablesChanged:
+            [self.cleverTap onceVariablesChanged:[handler variablesCallback:CleverTapUnityCallbackOneTimeVariablesChanged callbackId:callbackId]];
+            break;
+        case CleverTapUnityCallbackOneTimeVariablesChangedAndNoDownloadsPending:
+            [self.cleverTap onceVariablesChangedAndNoDownloadsPending:[handler variablesCallback:CleverTapUnityCallbackOneTimeVariablesChangedAndNoDownloadsPending callbackId:callbackId]];
+            break;
+        default:
+            NSLog(@"Callback is not a Variables Callback: %@", callbackName);
+            break;
     }
 }
 
@@ -420,13 +423,13 @@ static BOOL shouldDisableBuffers = YES;
 
 - (void)didReceiveRemoteNotification:(NSDictionary *)notification
                               isOpen:(BOOL)isOpen
-           openInForeground:(BOOL)openInForeground {
+                    openInForeground:(BOOL)openInForeground {
     if (openInForeground) {
         [self.cleverTap handleNotificationWithData:notification openDeepLinksInForeground:YES];
     } else {
         [self.cleverTap handleNotificationWithData:notification];
     }
-
+    
     [self sendRemoteNotificationCallbackToUnity:notification isOpen:isOpen];
 }
 
@@ -770,7 +773,7 @@ static BOOL shouldDisableBuffers = YES;
     if (json[@"negativeBtnText"]) {
         negativeBtnText = [json valueForKey:@"negativeBtnText"];
     }
-
+    
     //creates the builder instance with all the required parameters
     inAppBuilder = [[CTLocalInApp alloc] initWithInAppType:inAppType
                                                  titleText:titleText
@@ -817,7 +820,7 @@ static BOOL shouldDisableBuffers = YES;
         [inAppBuilder setBtnBorderRadius:btnBorderRadius];
     }
     return inAppBuilder;
-}  
+}
 
 - (void)promptForPushPermission:(BOOL)showFallbackSettings {
     [self.cleverTap promptForPushPermission:showFallbackSettings];
@@ -832,12 +835,12 @@ static BOOL shouldDisableBuffers = YES;
     if (@available(iOS 10.0, *)) {
         [self.cleverTap getNotificationPermissionStatusWithCompletionHandler:^(UNAuthorizationStatus status) {
             BOOL isPushEnabled = YES;
-                    if (status == UNAuthorizationStatusNotDetermined || status == UNAuthorizationStatusDenied) {
-                        isPushEnabled = NO;
-                    }
+            if (status == UNAuthorizationStatusNotDetermined || status == UNAuthorizationStatusDenied) {
+                isPushEnabled = NO;
+            }
             NSLog(@"[CleverTap isPushPermissionGranted: %d]", isPushEnabled);
             [[CleverTapUnityCallbackHandler sharedInstance] pushPermissionCallback:isPushEnabled];
-            }];
+        }];
     }
     else {
         // Fallback on earlier versions
@@ -880,7 +883,7 @@ static BOOL shouldDisableBuffers = YES;
 }
 
 - (void)syncVariables:(BOOL)isProduction {
-	[self.cleverTap syncVariables:isProduction];
+    [self.cleverTap syncVariables:isProduction];
 }
 
 - (void)fetchVariables:(int) callbackId
@@ -894,7 +897,7 @@ static BOOL shouldDisableBuffers = YES;
     NSError *error = nil;
     
     CTVar *var = nil;
-
+    
     if ([kind isEqualToString:@"integer"])
     {
         var = [self.cleverTap defineVar:name withInt:[defaultValue intValue]];
@@ -947,7 +950,7 @@ static BOOL shouldDisableBuffers = YES;
     if (value) {
         NSError *error;
         NSData *jsonData = [NSJSONSerialization dataWithJSONObject:value options:NSUTF8StringEncoding error:&error];
-
+        
         if (!jsonData) {
             NSLog(@"Error serializing JSON: %@", error);
             return nil;
@@ -981,7 +984,7 @@ NSDictionary *cleverTap_convertDateValues(NSDictionary *dictionary) {
     if (dictionary == nil) {
         return dictionary;
     }
-
+    
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithDictionary:dictionary];
     for (id key in dictionary) {
         id value = [dict objectForKey:key];
@@ -1136,7 +1139,7 @@ NSDictionary *cleverTap_convertDateValues(NSDictionary *dictionary) {
         NSLog(@"Custom template: %@ is not currently being presented", templateName);
         return nil;
     }
-
+    
     return context;
 }
 


### PR DESCRIPTION
## Overview
iOS CleverTapUnityCallbackInfo and CleverTapUnityCallback improvements.

Eliminates the risky index-based lookup. The old approach assumed enum values matched array indices. The dictionary approach ensures each CleverTapUnityCallback maps directly to its corresponding CleverTapUnityCallbackInfo.

Easier to add new enum values without breaking the sequence.

Creates a callback name to CleverTapUnityCallback dictionary for faster and easier access. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Implemented a new mapping mechanism for callback resolution that improves event lookup.
- **Refactor**
	- Streamlined internal callback processing by transitioning from list-based to dictionary-based management.
	- Optimized remote notification and variable handling for enhanced efficiency.
- **Style**
	- Made minor formatting improvements to bolster overall code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->