### PR TITLE
Fix defineVars CORS issue

### DIFF
--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRequest.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeRequest.cs
@@ -28,6 +28,7 @@ namespace CleverTapSDK.Native {
         }
 
         internal int? Timeout => _timeout;
+        internal string Path => _path;
         internal IReadOnlyList<KeyValuePair<string, string>> QueryParameters => _queryParameters;
         internal string RequestBody => _requestBody;
         internal IReadOnlyDictionary<string, string> Headers => _headers;

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeVariablesRequestInterceptor.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeVariablesRequestInterceptor.cs
@@ -1,0 +1,18 @@
+﻿#if UNITY_WEBGL && !UNITY_EDITOR
+using System.Collections.Generic;
+
+namespace CleverTapSDK.Native
+{
+    internal class UnityNativeVariablesRequestInterceptor : IUnityNativeRequestInterceptor
+    {
+        UnityNativeRequest IUnityNativeRequestInterceptor.Intercept(UnityNativeRequest request)
+        {
+            if (request.Path == UnityNativeConstants.Network.REQUEST_PATH_DEFINE_VARIABLES)
+            {
+                request.SetHeaders(new Dictionary<string, string>());
+            }
+            return request;
+        }
+    }
+}
+#endif

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeVariablesRequestInterceptor.cs.meta
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Models/UnityNativeVariablesRequestInterceptor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0a3d5c82fed344e7af36e125c8740d8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventManager.cs
@@ -47,6 +47,7 @@ namespace CleverTapSDK.Native
             _platformVariable?.Load(this, _callbackHandler, _coreState);
 
             // Requires network engine
+            SetRequestInterceptors();
             SetResponseInterceptors();
             _eventQueueManager = new UnityNativeEventQueueManager(_coreState, _networkEngine, _databaseStore);
         }
@@ -84,7 +85,20 @@ namespace CleverTapSDK.Native
 
             _networkEngine.SetResponseInterceptors(responseInterceptors);
         }
-        
+
+        /// <summary>
+        /// Sets request interceptors.
+        /// Requires network engine to be initialized.
+        /// </summary>
+        private void SetRequestInterceptors() {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            _networkEngine.SetRequestInterceptors(new List<IUnityNativeRequestInterceptor>
+            {
+                new UnityNativeVariablesRequestInterceptor()
+            });
+#endif
+        }
+
         #region Launch
 
         internal void LaunchWithCredentials(string accountId, string token, string region = null) {


### PR DESCRIPTION
## Overview
Remove additional headers for `defineVars` request on WebGL.
If additional headers are added, the request will fail due to CORS.