### PR TITLE
Fix - SDK-5113

### DIFF
--- a/CTExample/Assets/Scripts/AppInbox/MessageItem.cs
+++ b/CTExample/Assets/Scripts/AppInbox/MessageItem.cs
@@ -198,8 +198,6 @@ namespace CTExample
                     ReadMessage();
                     Application.OpenURL(url);
                 }
-
-                OnReadButtonClick();
             }
         }
 


### PR DESCRIPTION
Clicking on the slides opens the url along with opening the message in read state - Fixed