### PR TITLE
Fixed runtime NotSupportedException when trying to delete UnityNativeEventDBEntry

### DIFF
--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Scripts/UnityNativeEventDBEntry.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Scripts/UnityNativeEventDBEntry.cs
@@ -2,21 +2,22 @@
 using System;
 using SQLite4Unity3d;
 using UnityEngine;
+using UnityEngine.Scripting;
 
 namespace CleverTapSDK.Native
 {
     internal class UnityNativeEventDBEntry
     {
 #if UNITY_WEBGL && !UNITY_EDITOR
-        public int Id { get; set; }
+        [Preserve] public int Id { get; set; }
 #else
         [PrimaryKey, AutoIncrement]
-        public int Id { get; set; }
+        [Preserve] public int Id { get; set; }
 #endif
 
-        public UnityNativeEventType EventType { get; set; }
-        public string JsonContent { get; set; }
-        public long Timestamp { get; set; }
+        [Preserve] public UnityNativeEventType EventType { get; set; }
+        [Preserve] public string JsonContent { get; set; }
+        [Preserve] public long Timestamp { get; set; }
 
         public UnityNativeEventDBEntry()
         {


### PR DESCRIPTION
Fixed runtime NotSupportedException when trying to delete UnityNativeEventDBEntry in built clients using its primary key ID column caused by stripping of non-referenced setter methods of column properties in UnityNativeEventDBEntry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential data loss in database operations by ensuring event data properties are preserved during code optimization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->