### PR TITLE
Add Unity 6 application entry point note to CleverTap integration docs

### DIFF
--- a/docs/Instructions-Android.md
+++ b/docs/Instructions-Android.md
@@ -33,6 +33,17 @@
         ```
         Otherwise use `com.clevertap.unity.CleverTapOverrideActivity` as shown in the Manifest below.
 
+        #### Unity 6 – Application Entry Point Consideration
+        In **Unity 6**, the Android Player settings provide two application entry point options:
+
+        - **Activity**
+        - **GameActivity**
+
+        For CleverTap integration, ensure that the **Activity** option is selected in:
+
+        ```
+        Project Settings → Player → Android → Others Settings → Appication Entry Point
+        ```
 ```xml
 
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Added a new subsection under the CleverTap Integration Update section to clarify Unity 6 Application Entry Point settings.

The update instructs developers to select the Activity option (instead of GameActivity) when using CleverTap with Leanplum, ensuring correct configuration in Unity 6 Android Player settings.