### PR TITLE
Add - Unity 6 application entry point note to CleverTap integration docs

### DIFF
--- a/docs/Instructions-Android.md
+++ b/docs/Instructions-Android.md
@@ -42,7 +42,7 @@
         For CleverTap integration, ensure that the **Activity** option is selected in:
 
         ```
-        Project Settings → Player → Android
+        Project Settings → Player → Android → Other Settings → Application Entry Point
         ```
 ```xml
 


### PR DESCRIPTION
Added a new subsection under the CleverTap Integration Update section to clarify Unity 6 Application Entry Point settings.

The update instructs developers to select the Activity option (instead of GameActivity) when using CleverTap with Leanplum, ensuring correct configuration in Unity 6 Android Player settings.