### PR TITLE
Master - Add Unity 6 application entry point note to CleverTap integration docs

### DIFF
--- a/docs/Instructions-Android.md
+++ b/docs/Instructions-Android.md
@@ -33,17 +33,19 @@
         ```
         Otherwise use `com.clevertap.unity.CleverTapOverrideActivity` as shown in the Manifest below.
         
-        #### Unity 6 – Application Entry Point Consideration
-        In **Unity 6**, the Android Player settings provide two application entry point options:
+### Unity 6 – Application Entry Point Consideration
 
-        - **Activity**
-        - **GameActivity**
+In **Unity 6**, the Android Player settings provide two application entry point options:
 
-        For CleverTap integration, ensure that the **Activity** option is selected in:
+- **Activity**
+- **GameActivity**
 
-        ```
-        Project Settings → Player → Android → Other Settings → Application Entry Point
-        ```
+For CleverTap integration, ensure that the **Activity** option is selected in:
+
+```text
+Project Settings → Player → Android → Other Settings → Application Entry Point
+```
+
 ```xml
 
 <?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
Added a new subsection under the CleverTap Integration Update section to clarify Unity 6 Application Entry Point settings.

The update instructs developers to select the Activity option (instead of GameActivity) when using CleverTap with Leanplum, ensuring correct configuration in Unity 6 Android Player settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Unity 6 Android guidance describing the two possible application entry points (Activity and GameActivity), clarifying that Activity should be selected in Android Player settings, and placing this guidance alongside existing Launcher Activity instructions to help configure Android builds correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->