### PR TITLE
Update CleverTap SDK versions for Android and iOS

### DIFF
--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/build.gradle
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/build.gradle
@@ -10,7 +10,7 @@ ext {
     compileSdkVersionVal = 36
     targetSdkVersionVal = compileSdkVersionVal
 
-    libraryVersion = "5.4.0"
+    libraryVersion = "5.5.0"
 }
 
 android {
@@ -55,7 +55,7 @@ android {
 dependencies {
     compileOnly fileTree('libs')
 
-    api 'com.clevertap.android:clevertap-android-sdk:7.7.0'
+    api 'com.clevertap.android:clevertap-android-sdk:7.7.1'
     implementation "androidx.core:core:1.13.0"
     implementation "com.google.firebase:firebase-messaging:24.0.0"
 }

--- a/CleverTap/Plugins/Editor/CleverTapDependencies.xml
+++ b/CleverTap/Plugins/Editor/CleverTapDependencies.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <dependencies>
     <iosPods>
-        <iosPod name="CleverTap-iOS-SDK" version="7.4.0" minTargetSdk="9.0" />
+        <iosPod name="CleverTap-iOS-SDK" version="7.4.1" minTargetSdk="9.0" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
Updated Android SDK to 7.7.1 and iOS SDK to 7.4.1. Also updated the Android wrapper library version to 5.5.0 to reflect these changes.