### PR TITLE
Track app launch event processing state - Queue Custom Events

### DIFF
--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventQueueManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventQueueManager.cs
@@ -1,4 +1,5 @@
 #if (!UNITY_IOS && !UNITY_ANDROID) || UNITY_EDITOR
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using CleverTapSDK.Utilities;
@@ -8,11 +9,11 @@ namespace CleverTapSDK.Native
     internal class UnityNativeEventQueueManager
     {
         private readonly UnityNativeDatabaseStore _databaseStore;
-
         private readonly UnityNativeBaseEventQueue _userEventsQueue;
         private readonly UnityNativeBaseEventQueue _raisedEventsQueue;
         private readonly UnityNativeBaseEventQueue _singleEventsQueue;
         private readonly UnityNativeBaseEventQueue _notificationViewedEventQueue;
+        public Action<UnityNativeEvent> OnEventProcessed { get; set; }
 
         internal UnityNativeEventQueueManager(UnityNativeCoreState coreState, UnityNativeNetworkEngine networkEngine, UnityNativeDatabaseStore databaseStore)
         {
@@ -41,6 +42,9 @@ namespace CleverTapSDK.Native
 
         private void OnEventsProcessed(List<UnityNativeEvent> flushedEvents)
         {
+            foreach (UnityNativeEvent item in flushedEvents)
+                OnEventProcessed?.Invoke(item);
+
             _databaseStore.DeleteEvents(flushedEvents);
         }
 

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventQueueManager.cs
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/UnityNativeEventQueueManager.cs
@@ -13,7 +13,7 @@ namespace CleverTapSDK.Native
         private readonly UnityNativeBaseEventQueue _raisedEventsQueue;
         private readonly UnityNativeBaseEventQueue _singleEventsQueue;
         private readonly UnityNativeBaseEventQueue _notificationViewedEventQueue;
-        public Action<UnityNativeEvent> OnEventProcessed { get; set; }
+        internal Action<UnityNativeEvent> OnEventProcessed { get; set; }
 
         internal UnityNativeEventQueueManager(UnityNativeCoreState coreState, UnityNativeNetworkEngine networkEngine, UnityNativeDatabaseStore databaseStore)
         {


### PR DESCRIPTION
Introduces a flag to track if the app launch event has been processed and updates event queuing logic to defer events until processing is complete. Adds an OnEventProcessed callback in UnityNativeEventQueueManager to notify when events are processed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced app-launch event handling with improved event sequencing during application startup.
  * Non-app-launch events are now deferred until app-launch processing is complete.

* **Improvements**
  * Added event processing callbacks to better monitor event queue operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->