### PR TITLE
feature/multi-environment-credentials

### DIFF
--- a/CTExample/Assets/Editor/IOSPushNotificationsPostBuildProcessor.cs
+++ b/CTExample/Assets/Editor/IOSPushNotificationsPostBuildProcessor.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CleverTapSDK.Private;
+using CleverTapSDK.Utilities;
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Callbacks;
@@ -318,6 +319,18 @@ namespace CTExample
                 throw new BuildFailedException("[CTExample] CleverTapSettings is null. Cannot configure push impressions.");
             }
 
+            Dictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> environments = settings.Environments.ToDictionary();
+
+            if (environments == null || environments.Count == 0)
+            {
+                throw new BuildFailedException("[CTExample] CleverTapSettings - Environments are not configured.");
+            }
+
+            if(!environments.TryGetValue(settings.DefaultEnvionment, out CleverTapEnvironmentCredential environmentValue))
+            {
+                throw new BuildFailedException($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvionment}");
+            }
+
             string plistPath = Path.Combine(path, InfoPropertyList);
             if (!File.Exists(plistPath))
             {
@@ -328,9 +341,9 @@ namespace CTExample
             plist.ReadFromString(File.ReadAllText(plistPath));
 
             PlistElementDict rootDict = plist.root;
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapAccountId))
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapAccountId))
             {
-                rootDict.SetString("CleverTapAccountID", settings.CleverTapAccountId);
+                rootDict.SetString("CleverTapAccountID", environmentValue.CleverTapAccountId);
             }
             else
             {
@@ -340,9 +353,9 @@ namespace CTExample
                     $"manually in the project Info.plist.");
             }
 
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapAccountToken))
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapAccountToken))
             {
-                rootDict.SetString("CleverTapToken", settings.CleverTapAccountToken);
+                rootDict.SetString("CleverTapToken", environmentValue.CleverTapAccountToken);
             }
             else
             {
@@ -352,17 +365,17 @@ namespace CTExample
                     $"manually in the project Info.plist.");
             }
 
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapAccountRegion))
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapAccountRegion))
             {
-                rootDict.SetString("CleverTapRegion", settings.CleverTapAccountRegion);
+                rootDict.SetString("CleverTapRegion", environmentValue.CleverTapAccountRegion);
             }
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapProxyDomain))
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapProxyDomain))
             {
-                rootDict.SetString("CleverTapProxyDomain", settings.CleverTapProxyDomain);
+                rootDict.SetString("CleverTapProxyDomain", environmentValue.CleverTapProxyDomain);
             }
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapSpikyProxyDomain))
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapSpikyProxyDomain))
             {
-                rootDict.SetString("CleverTapSpikyProxyDomain", settings.CleverTapSpikyProxyDomain);
+                rootDict.SetString("CleverTapSpikyProxyDomain", environmentValue.CleverTapSpikyProxyDomain);
             }
             rootDict.SetBoolean("CleverTapDisableIDFV", settings.CleverTapDisableIDFV);
 

--- a/CTExample/Assets/Editor/IOSPushNotificationsPostBuildProcessor.cs
+++ b/CTExample/Assets/Editor/IOSPushNotificationsPostBuildProcessor.cs
@@ -319,16 +319,21 @@ namespace CTExample
                 throw new BuildFailedException("[CTExample] CleverTapSettings is null. Cannot configure push impressions.");
             }
 
-            Dictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> environments = settings.Environments.ToDictionary();
-
-            if (environments == null || environments.Count == 0)
+            if (settings.Environments == null || settings.Environments.Items == null)
             {
                 throw new BuildFailedException("[CTExample] CleverTapSettings - Environments are not configured.");
             }
 
-            if(!environments.TryGetValue(settings.DefaultEnvionment, out CleverTapEnvironmentCredential environmentValue))
+            Dictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> environments = settings.Environments.ToDictionary();
+
+            if (environments.Count == 0)
             {
-                throw new BuildFailedException($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvionment}");
+                throw new BuildFailedException("[CTExample] CleverTapSettings - Environments are not configured.");
+            }
+
+            if (!environments.TryGetValue(settings.DefaultEnvironment, out CleverTapEnvironmentCredential environmentValue))
+            {
+                throw new BuildFailedException($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvironment}");
             }
 
             string plistPath = Path.Combine(path, InfoPropertyList);

--- a/CTExample/Assets/Scripts/Utilities/CleverTapSettingsRuntime.cs
+++ b/CTExample/Assets/Scripts/Utilities/CleverTapSettingsRuntime.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using CleverTapSDK.Utilities;
 using UnityEngine;
 #if UNITY_WEBGL && !UNITY_EDITOR
 using System.Threading.Tasks;
@@ -22,9 +24,13 @@ namespace CTExample
         private static readonly object _lock = new object();
 #endif
 
-        public string CleverTapAccountId;
-        public string CleverTapAccountToken;
-        public string CleverTapAccountRegion;
+        public CleverTapEnvironmentKey DefaultEnvironment = Debug.isDebugBuild ? Enum.Parse<CleverTapEnvironmentKey>(PlayerPrefs.GetString("CleverTapEnvironment", "PROD"))
+        : CleverTapEnvironmentKey.PROD;
+       
+        public SerializableDictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> Environments = new SerializableDictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential>();
+        public string CleverTapAccountId => Environments.ToDictionary()[DefaultEnvironment].CleverTapAccountId;
+        public string CleverTapAccountToken => Environments.ToDictionary()[DefaultEnvironment].CleverTapAccountToken;
+        public string CleverTapAccountRegion => Environments.ToDictionary()[DefaultEnvironment].CleverTapAccountRegion;
 
 #if !(UNITY_WEBGL && !UNITY_EDITOR)
         public static CleverTapSettingsRuntime Instance

--- a/CleverTap/Editor/AndroidProjectPostProcessor.cs
+++ b/CleverTap/Editor/AndroidProjectPostProcessor.cs
@@ -47,17 +47,23 @@ namespace CleverTapSDK.Private
                 return;
             }
 
-            Dictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> environmentCredentials = settings.Environments.ToDictionary();
-
-            if (environmentCredentials == null || environmentCredentials.Count == 0)
+            if(settings.Environments == null || settings.Environments.Items == null)
             {
                 Debug.LogError("[CTExample] CleverTapSettings - Environments are not configured.");
                 return;
             }
 
-            if (!environmentCredentials.TryGetValue(settings.DefaultEnvionment, out CleverTapEnvironmentCredential environmentCredential))
+            Dictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> environmentCredentials = settings.Environments.ToDictionary();
+
+            if (environmentCredentials.Count == 0)
             {
-                Debug.LogError($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvionment}");
+                Debug.LogError("[CTExample] CleverTapSettings - Environments are not configured.");
+                return;
+            }
+
+            if (!environmentCredentials.TryGetValue(settings.DefaultEnvironment, out CleverTapEnvironmentCredential environmentCredential))
+            {
+                Debug.LogError($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvironment}");
                 return;
             }
 
@@ -98,8 +104,8 @@ namespace CleverTapSDK.Private
             if (isDevelopmentBuild)
             {
                 Debug.Log($"[CleverTap] Development Build - Writing {environmentCredentials.Count} additional environment(s) to AndroidManifest.xml");
-                UpdateMetaDataNode(manifestXml, applicationNode, namespaceManager, "CLEVERTAP_DEFAULT_ENV", settings.DefaultEnvionment.ToString());
-                Debug.Log($"[CleverTap] Setting default environment to: {settings.DefaultEnvionment}");
+                UpdateMetaDataNode(manifestXml, applicationNode, namespaceManager, "CLEVERTAP_DEFAULT_ENV", settings.DefaultEnvironment.ToString());
+                Debug.Log($"[CleverTap] Setting default environment to: {settings.DefaultEnvironment}");
 
                 foreach (KeyValuePair<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> cred in environmentCredentials)
                 {

--- a/CleverTap/Editor/CleverTapSettings.cs
+++ b/CleverTap/Editor/CleverTapSettings.cs
@@ -1,4 +1,6 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using CleverTapSDK.Utilities;
 using UnityEngine;
 
 namespace CleverTapSDK.Private
@@ -7,30 +9,9 @@ namespace CleverTapSDK.Private
     public class CleverTapSettings : ScriptableObject
     {
         #region Project Settings
-        /// <summary>
-        /// CleverTap project Account Id (Project ID).
-        /// </summary>
-        public string CleverTapAccountId;
+        public CleverTapEnvironmentKey DefaultEnvionment = CleverTapEnvironmentKey.PROD;
 
-        /// <summary>
-        /// CleverTap project Account token (Project Token).
-        /// </summary>
-        public string CleverTapAccountToken;
-
-        /// <summary>
-        /// CleverTap Region Code.
-        /// </summary>
-        public string CleverTapAccountRegion;
-
-        /// <summary>
-        /// Custom Proxy Domain.
-        /// </summary>
-        public string CleverTapProxyDomain;
-
-        /// <summary>
-        /// Spiky Proxy Domain.
-        /// </summary>
-        public string CleverTapSpikyProxyDomain;
+        public SerializableDictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> Environments = new SerializableDictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential>();
         #endregion
 
         #region IOS Specific Settings
@@ -43,7 +24,7 @@ namespace CleverTapSDK.Private
         /// Boolean whether to use auto integrate on iOS.
         /// Default value is true.
         /// </summary>
-        public bool CleverTapIOSUseAutoIntegrate { get; set; } = true;
+        public bool CleverTapIOSUseAutoIntegrate = true;
 
         /// <summary>
         /// Boolean whether to set UNUserNotificationCenter delegate on iOS.
@@ -51,7 +32,7 @@ namespace CleverTapSDK.Private
         /// If set to false, you must implement the center delegate
         /// methods yourself and call the CleverTap methods.
         /// </summary>
-        public bool CleverTapIOSUseUNUserNotificationCenter { get; set; } = true;
+        public bool CleverTapIOSUseUNUserNotificationCenter = true;
 
         /// <summary>
         /// Boolean whether to present remote notifications while app is on foreground on iOS.
@@ -74,11 +55,8 @@ namespace CleverTapSDK.Private
         public override string ToString()
         {
             return $"CleverTapSettings:\n" +
-                   $"CleverTapAccountId: {CleverTapAccountId}\n" +
-                   $"CleverTapAccountToken: {CleverTapAccountToken}\n" +
-                   $"CleverTapAccountRegion: {CleverTapAccountRegion}\n" +
-                   $"CleverTapProxyDomain: {CleverTapProxyDomain}\n" +
-                   $"CleverTapSpikyProxyDomain: {CleverTapSpikyProxyDomain}\n" +
+                   $"CleverTap Default Environment : {DefaultEnvionment}\n" +
+                   $"CleverTap Environments : {JsonUtility.ToJson(Environments)}\n" +
                    $"CleverTapDisableIDFV: {CleverTapDisableIDFV}\n" +
                    $"CleverTapIOSUseAutoIntegrate: {CleverTapIOSUseAutoIntegrate}\n" +
                    $"CleverTapIOSUseUNUserNotificationCenter: {CleverTapIOSUseUNUserNotificationCenter}\n" +

--- a/CleverTap/Editor/CleverTapSettings.cs
+++ b/CleverTap/Editor/CleverTapSettings.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using CleverTapSDK.Utilities;
 using UnityEngine;
 
@@ -9,7 +8,7 @@ namespace CleverTapSDK.Private
     public class CleverTapSettings : ScriptableObject
     {
         #region Project Settings
-        public CleverTapEnvironmentKey DefaultEnvionment = CleverTapEnvironmentKey.PROD;
+        public CleverTapEnvironmentKey DefaultEnvironment = CleverTapEnvironmentKey.PROD;
 
         public SerializableDictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> Environments = new SerializableDictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential>();
         #endregion
@@ -55,7 +54,7 @@ namespace CleverTapSDK.Private
         public override string ToString()
         {
             return $"CleverTapSettings:\n" +
-                   $"CleverTap Default Environment : {DefaultEnvionment}\n" +
+                   $"CleverTap Default Environment : {DefaultEnvironment}\n" +
                    $"CleverTap Environments : {JsonUtility.ToJson(Environments)}\n" +
                    $"CleverTapDisableIDFV: {CleverTapDisableIDFV}\n" +
                    $"CleverTapIOSUseAutoIntegrate: {CleverTapIOSUseAutoIntegrate}\n" +

--- a/CleverTap/Editor/IOSPostBuildProcessor.cs
+++ b/CleverTap/Editor/IOSPostBuildProcessor.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_IOS && UNITY_EDITOR
+﻿#if !UNITY_IOS && UNITY_EDITOR
 using System.Collections.Generic;
 using System.IO;
 using CleverTapSDK.Utilities;
@@ -120,6 +120,12 @@ namespace CleverTapSDK.Private
 
             PlistElementDict rootDict = plist.root;
 
+            if (settings.Environments == null || settings.Environments.Items == null)
+            {
+                Debug.LogError("[CTExample] CleverTapSettings - Environments are not configured.");
+                return;
+            }
+
             Dictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> environments = settings.Environments.ToDictionary();
 
             if (environments == null || environments.Count == 0)
@@ -128,9 +134,9 @@ namespace CleverTapSDK.Private
                 return;
             }
 
-            if (!environments.TryGetValue(settings.DefaultEnvionment, out CleverTapEnvironmentCredential environmentValue))
+            if (!environments.TryGetValue(settings.DefaultEnvironment, out CleverTapEnvironmentCredential environmentValue))
             {
-                Debug.LogError($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvionment}");
+                Debug.LogError($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvironment}");
                 return;
             }
 
@@ -174,27 +180,27 @@ namespace CleverTapSDK.Private
             if (isDevelopmentBuild)
             {
                 Debug.Log($"[CleverTap] Development Build - Writing {environments.Count} additional environment(s) to Info.plist");
-                rootDict.SetString("CleverTapDefaultEnv", settings.DefaultEnvionment.ToString());
+                rootDict.SetString("CleverTapDefaultEnv", settings.DefaultEnvironment.ToString());
 
                 foreach (KeyValuePair<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> env in environments)
                 {
                     string suffix = "_" + env.Key.ToString();
-                    
+
                     if (!string.IsNullOrWhiteSpace(env.Value.CleverTapAccountId))
                         rootDict.SetString("CleverTapAccountID" + suffix, env.Value.CleverTapAccountId);
-                    
+
                     if (!string.IsNullOrWhiteSpace(env.Value.CleverTapAccountToken))
                         rootDict.SetString("CleverTapToken" + suffix, env.Value.CleverTapAccountToken);
-                    
+
                     if (!string.IsNullOrWhiteSpace(env.Value.CleverTapAccountRegion))
                         rootDict.SetString("CleverTapRegion" + suffix, env.Value.CleverTapAccountRegion);
-                    
+
                     if (!string.IsNullOrWhiteSpace(env.Value.CleverTapProxyDomain))
                         rootDict.SetString("CleverTapProxyDomain" + suffix, env.Value.CleverTapProxyDomain);
-                    
+
                     if (!string.IsNullOrWhiteSpace(env.Value.CleverTapSpikyProxyDomain))
                         rootDict.SetString("CleverTapSpikyProxyDomain" + suffix, env.Value.CleverTapSpikyProxyDomain);
-                    
+
                     Debug.Log($"[CleverTap] Added environment: {env.Key} with AccountID: {env.Value.CleverTapAccountId}");
                 }
             }

--- a/CleverTap/Editor/IOSPostBuildProcessor.cs
+++ b/CleverTap/Editor/IOSPostBuildProcessor.cs
@@ -1,6 +1,7 @@
 ﻿#if UNITY_IOS && UNITY_EDITOR
 using System.Collections.Generic;
 using System.IO;
+using CleverTapSDK.Utilities;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.iOS.Xcode;
@@ -9,15 +10,15 @@ using UnityEngine;
 namespace CleverTapSDK.Private
 {
     public static class IOSPostBuildProcessor
-	{
+    {
         [PostProcessBuild(99)]
-		public static void OnPostProcessBuild(BuildTarget target, string path)
-		{
-			if (target == BuildTarget.iOS)
-			{
-				IOSPostProcess(path);
-			}
-		}
+        public static void OnPostProcessBuild(BuildTarget target, string path)
+        {
+            if (target == BuildTarget.iOS)
+            {
+                IOSPostProcess(path);
+            }
+        }
 
         private static void IOSPostProcess(string path)
         {
@@ -48,9 +49,9 @@ namespace CleverTapSDK.Private
         {
             if (settings != null)
             {
-                UpdatePlistWithSettings(path, settings);
-
-                UpdatePreprocessorMacros(proj, projectTarget, settings);
+                bool isDevelopmentBuild = EditorUserBuildSettings.development;
+                UpdatePlistWithSettings(path, settings, isDevelopmentBuild);
+                UpdatePreprocessorMacros(proj, projectTarget, settings, isDevelopmentBuild);
             }
             else
             {
@@ -67,11 +68,23 @@ namespace CleverTapSDK.Private
         /// <param name="proj">The project to update.</param>
         /// <param name="projectTarget">The project target guid.</param>
         /// <param name="settings">The CleverTapSettings to use.</param>
-        private static void UpdatePreprocessorMacros(PBXProject proj, string projectTarget, CleverTapSettings settings)
+        private static void UpdatePreprocessorMacros(PBXProject proj, string projectTarget, CleverTapSettings settings, bool isDevelopmentBuild)
         {
             // The UpdateBuildProperty set the property value if no values are present. This overrides the $(inherited) value.
             // Add the $(inherited) value as a workaround.
             string preprocessorMacros = "GCC_PREPROCESSOR_DEFINITIONS";
+
+            // Add DEBUG macro for development builds to enable environment switching
+            if (isDevelopmentBuild)
+            {
+                proj.UpdateBuildProperty(projectTarget, preprocessorMacros, new string[] { "$(inherited)", "DEBUG=1" }, null);
+                Debug.Log("[CleverTap] Development Build - Added DEBUG preprocessor macro");
+            }
+            else
+            {
+                proj.UpdateBuildProperty(projectTarget, preprocessorMacros, null, new string[] { "DEBUG", "DEBUG=1" });
+            }
+
             if (!settings.CleverTapIOSUseAutoIntegrate)
             {
                 proj.UpdateBuildProperty(projectTarget, preprocessorMacros, new string[] { "$(inherited)", "NO_AUTOINTEGRATE" }, null);
@@ -96,7 +109,7 @@ namespace CleverTapSDK.Private
         /// </summary>
         /// <param name="path">The project path.</param>
         /// <param name="settings">The settings to use.</param>
-        private static void UpdatePlistWithSettings(string path, CleverTapSettings settings)
+        private static void UpdatePlistWithSettings(string path, CleverTapSettings settings, bool isDevelopmentBuild)
         {
             if (settings == null)
                 return;
@@ -106,9 +119,24 @@ namespace CleverTapSDK.Private
             plist.ReadFromString(File.ReadAllText(plistPath));
 
             PlistElementDict rootDict = plist.root;
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapAccountId))
+
+            Dictionary<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> environments = settings.Environments.ToDictionary();
+
+            if (environments == null || environments.Count == 0)
             {
-                rootDict.SetString("CleverTapAccountID", settings.CleverTapAccountId);
+                Debug.LogError("[CTExample] CleverTapSettings - Environments are not configured.");
+                return;
+            }
+
+            if (!environments.TryGetValue(settings.DefaultEnvionment, out CleverTapEnvironmentCredential environmentValue))
+            {
+                Debug.LogError($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvionment}");
+                return;
+            }
+
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapAccountId))
+            {
+                rootDict.SetString("CleverTapAccountID", environmentValue.CleverTapAccountId);
             }
             else
             {
@@ -118,9 +146,9 @@ namespace CleverTapSDK.Private
                     $"manually in the project Info.plist.");
             }
 
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapAccountToken))
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapAccountToken))
             {
-                rootDict.SetString("CleverTapToken", settings.CleverTapAccountToken);
+                rootDict.SetString("CleverTapToken", environmentValue.CleverTapAccountToken);
             }
             else
             {
@@ -130,40 +158,67 @@ namespace CleverTapSDK.Private
                     $"manually in the project Info.plist.");
             }
 
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapAccountRegion))
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapAccountRegion))
             {
-                rootDict.SetString("CleverTapRegion", settings.CleverTapAccountRegion);
+                rootDict.SetString("CleverTapRegion", environmentValue.CleverTapAccountRegion);
             }
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapProxyDomain))
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapProxyDomain))
             {
-                rootDict.SetString("CleverTapProxyDomain", settings.CleverTapProxyDomain);
+                rootDict.SetString("CleverTapProxyDomain", environmentValue.CleverTapProxyDomain);
             }
-            if (!string.IsNullOrWhiteSpace(settings.CleverTapSpikyProxyDomain))
+            if (!string.IsNullOrWhiteSpace(environmentValue.CleverTapSpikyProxyDomain))
             {
-                rootDict.SetString("CleverTapSpikyProxyDomain", settings.CleverTapSpikyProxyDomain);
+                rootDict.SetString("CleverTapSpikyProxyDomain", environmentValue.CleverTapSpikyProxyDomain);
+            }
+
+            if (isDevelopmentBuild)
+            {
+                Debug.Log($"[CleverTap] Development Build - Writing {environments.Count} additional environment(s) to Info.plist");
+                rootDict.SetString("CleverTapDefaultEnv", settings.DefaultEnvionment.ToString());
+
+                foreach (KeyValuePair<CleverTapEnvironmentKey, CleverTapEnvironmentCredential> env in environments)
+                {
+                    string suffix = "_" + env.Key.ToString();
+                    
+                    if (!string.IsNullOrWhiteSpace(env.Value.CleverTapAccountId))
+                        rootDict.SetString("CleverTapAccountID" + suffix, env.Value.CleverTapAccountId);
+                    
+                    if (!string.IsNullOrWhiteSpace(env.Value.CleverTapAccountToken))
+                        rootDict.SetString("CleverTapToken" + suffix, env.Value.CleverTapAccountToken);
+                    
+                    if (!string.IsNullOrWhiteSpace(env.Value.CleverTapAccountRegion))
+                        rootDict.SetString("CleverTapRegion" + suffix, env.Value.CleverTapAccountRegion);
+                    
+                    if (!string.IsNullOrWhiteSpace(env.Value.CleverTapProxyDomain))
+                        rootDict.SetString("CleverTapProxyDomain" + suffix, env.Value.CleverTapProxyDomain);
+                    
+                    if (!string.IsNullOrWhiteSpace(env.Value.CleverTapSpikyProxyDomain))
+                        rootDict.SetString("CleverTapSpikyProxyDomain" + suffix, env.Value.CleverTapSpikyProxyDomain);
+                    
+                    Debug.Log($"[CleverTap] Added environment: {env.Key} with AccountID: {env.Value.CleverTapAccountId}");
+                }
             }
 
             rootDict.SetBoolean("CleverTapDisableIDFV", settings.CleverTapDisableIDFV);
-
             rootDict.SetBoolean("CleverTapPresentNotificationForeground", settings.CleverTapIOSPresentNotificationOnForeground);
 
             // Write to file
             File.WriteAllText(plistPath, plist.WriteToString());
         }
 
-		/// <summary>
-		/// Copies the CleverTap folder (Assets/CleverTap) to the iOS exported project.
-		/// The copied folder has "Build Rules" - "Apply Once to Folder".
-		/// The folder is added to the "Copy Bundle Resources" Build Phase.
-		/// The folder is with "Location" - "Relative to Group" and appears blue in Xcode.
-		/// The folder has "Target Membership" the main target - "Unity-iPhone".
-		/// </summary>
-		/// <remarks>
-		/// The folder must be copied with a different name than the original one in the Assets (CleverTap -> CleverTapSDK),
-		/// otherwise its contents do not appear correctly in Xcode but will still be copied into the bundle.
-		/// </remarks>
-		/// <param name="path">The project path.</param>
-		/// <param name="proj">The Xcode project.</param>
+        /// <summary>
+        /// Copies the CleverTap folder (Assets/CleverTap) to the iOS exported project.
+        /// The copied folder has "Build Rules" - "Apply Once to Folder".
+        /// The folder is added to the "Copy Bundle Resources" Build Phase.
+        /// The folder is with "Location" - "Relative to Group" and appears blue in Xcode.
+        /// The folder has "Target Membership" the main target - "Unity-iPhone".
+        /// </summary>
+        /// <remarks>
+        /// The folder must be copied with a different name than the original one in the Assets (CleverTap -> CleverTapSDK),
+        /// otherwise its contents do not appear correctly in Xcode but will still be copied into the bundle.
+        /// </remarks>
+        /// <param name="path">The project path.</param>
+        /// <param name="proj">The Xcode project.</param>
         private static void CopyAssetsToIOSResources(string path, PBXProject proj)
         {
             string sourceFolderPath = Path.Combine(Application.dataPath, EditorUtils.CLEVERTAP_ASSETS_FOLDER);
@@ -191,6 +246,6 @@ namespace CleverTapSDK.Private
             string folderGuid = proj.AddFolderReference(EditorUtils.CLEVERTAP_APP_ASSETS_FOLDER, EditorUtils.CLEVERTAP_APP_ASSETS_FOLDER);
             proj.AddFileToBuild(mainTargetGuid, folderGuid);
         }
-	}
+    }
 }
 #endif

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityAPI.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityAPI.java
@@ -178,6 +178,12 @@ public class CleverTapUnityAPI {
                 String region = metaData.getString("CLEVERTAP_REGION" + envSuffix);
                 String proxyDomain = metaData.getString("CLEVERTAP_PROXY_DOMAIN" + envSuffix);
                 String spikyProxyDomain = metaData.getString("CLEVERTAP_SPIKY_PROXY_DOMAIN" + envSuffix);
+                
+                if (accountId == null || accountId.isEmpty() || token == null || token.isEmpty()) {
+                    Log.w("CleverTap", "Missing accountId/token in manifest meta-data, using default instance");
+                    setCleverTapApiInstance(CleverTapAPI.getDefaultInstance(context));
+                    return;
+                }
 
                 CleverTapInstanceConfig config;
                 if (region != null && !region.isEmpty()) {

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityAPI.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityAPI.java
@@ -178,7 +178,7 @@ public class CleverTapUnityAPI {
                 String region = metaData.getString("CLEVERTAP_REGION" + envSuffix);
                 String proxyDomain = metaData.getString("CLEVERTAP_PROXY_DOMAIN" + envSuffix);
                 String spikyProxyDomain = metaData.getString("CLEVERTAP_SPIKY_PROXY_DOMAIN" + envSuffix);
-                
+
                 if (accountId == null || accountId.isEmpty() || token == null || token.isEmpty()) {
                     Log.w("CleverTap", "Missing accountId/token in manifest meta-data, using default instance");
                     setCleverTapApiInstance(CleverTapAPI.getDefaultInstance(context));
@@ -190,12 +190,13 @@ public class CleverTapUnityAPI {
                     config = CleverTapInstanceConfig.createInstance(context, accountId, token, region);
                 } else {
                     config = CleverTapInstanceConfig.createInstance(context, accountId, token);
-                    if (proxyDomain != null && !proxyDomain.isEmpty()) {
-                        config.setProxyDomain(proxyDomain);
-                    }
-                    if (spikyProxyDomain != null && !spikyProxyDomain.isEmpty()) {
-                        config.setSpikyProxyDomain(spikyProxyDomain);
-                    }
+                }
+
+                if (proxyDomain != null && !proxyDomain.isEmpty()) {
+                    config.setProxyDomain(proxyDomain);
+                }
+                if (spikyProxyDomain != null && !spikyProxyDomain.isEmpty()) {
+                    config.setSpikyProxyDomain(spikyProxyDomain);
                 }
 
                 CleverTapAPI instance = CleverTapAPI.instanceWithConfig(context, config);

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityApplication.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityApplication.java
@@ -8,8 +8,12 @@ public class CleverTapUnityApplication extends Application {
 
     @Override
     public void onCreate() {
+        // Initialize CleverTap with custom environment-aware config BEFORE calling super.onCreate()
+        // and BEFORE registering ActivityLifecycleCallback to prevent auto-initialization
+        CleverTapUnityAPI.initialize(this);
+        
+        // Now register the lifecycle callback with the already-configured instance
         ActivityLifecycleCallback.register(this);
         super.onCreate();
-        CleverTapUnityAPI.initialize(this);
     }
 }

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
@@ -164,6 +164,42 @@ public class CleverTapUnityPlugin {
         }
     }
 
+    @Nullable
+    static synchronized String getUnityPlayerPrefsString(Context context, String key) {
+        if (context == null || key == null) {
+            return null;
+        }
+        
+        String packageName = context.getPackageName();
+        String[] possibleFiles = new String[] {
+            "unity." + packageName + ".v2.playerprefs",  // Most common for newer Unity
+            "com.unity3d.player.UnityPlayer",            // Another common pattern
+            "UnityPlayerPrefs",                          // Older Unity versions
+            packageName + ".v2.playerprefs",             // Alternative pattern
+            "PlayerPrefs",                               // Simple pattern
+            "unity.playerprefs"                          // Simple Unity pattern
+        };
+        
+        for (String prefFile : possibleFiles) {
+            try {
+                android.content.SharedPreferences prefs = context.getSharedPreferences(
+                    prefFile,
+                    Context.MODE_PRIVATE
+                );
+                String value = prefs.getString(key, null);
+                if (value != null) {
+                    Log.d(LOG_TAG, "Found key '" + key + "' = '" + value + "' in file: " + prefFile);
+                    return value;
+                }
+            } catch (Exception e) {
+                Log.d(LOG_TAG, "Failed to read from " + prefFile + ": " + e.getMessage());
+            }
+        }
+        
+        Log.d(LOG_TAG, "Key '" + key + "' not found in any PlayerPrefs file");
+        return null;
+    }
+
     private CleverTapUnityPlugin(final @NonNull CleverTapAPI cleverTapApi) {
         callbackHandler = CleverTapUnityCallbackHandler.getInstance();
         backgroundExecutor = new BackgroundExecutor();

--- a/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
+++ b/CleverTap/Plugins/iOS/CleverTapUnityAppController.m
@@ -28,11 +28,41 @@
 #endif
     
 #ifdef NO_AUTOINTEGRATE
-    NSString *_accountId = [self metaDataForAttribute:CT_ACCOUNT_ID_LABEL];
-    NSString *_accountToken = [self metaDataForAttribute:CT_TOKEN_LABEL];
-    NSString *_accountRegion = [self metaDataForAttribute:CT_REGION_LABEL];
-    NSString *_proxyDomain = [self metaDataForAttribute:CT_PROXY_DOMAIN_LABEL];
-    NSString *_spikyProxyDomain = [self metaDataForAttribute:CT_SPIKY_PROXY_DOMAIN_LABEL];
+
+    NSString *envSuffix = @"";
+    #ifdef DEBUG
+    // Development builds: Read environment from PlayerPrefs
+    NSString *environment = [CleverTapUnityManager getUnityPlayerPrefsString:@"CleverTapEnvironment"];
+    if (environment && environment.length > 0) {
+        envSuffix = [NSString stringWithFormat:@"_%@", environment];
+        NSLog(@"[CleverTap] DEBUG build - Using environment from PlayerPrefs: %@", environment);
+    } else {
+        // No PlayerPrefs set, check for default environment from plist
+        NSString *defaultEnv = [self metaDataForAttribute:@"CleverTapDefaultEnv"];
+        if (defaultEnv && defaultEnv.length > 0) {
+            envSuffix = [NSString stringWithFormat:@"_%@", defaultEnv];
+            NSLog(@"[CleverTap] DEBUG build - Using default environment from plist: %@", defaultEnv);
+        } else {
+            NSLog(@"[CleverTap] DEBUG build - No environment set, using primary");
+        }
+    }
+#else
+    // Release builds: Always use primary environment (base keys)
+    NSLog(@"[CleverTap] RELEASE build - Using primary environment");
+#endif
+    
+    NSString *accountIdKey = [CT_ACCOUNT_ID_LABEL stringByAppendingString:envSuffix];
+    NSString *tokenKey = [CT_TOKEN_LABEL stringByAppendingString:envSuffix];
+    NSString *regionKey = [CT_REGION_LABEL stringByAppendingString:envSuffix];
+    NSString *proxyDomainKey = [CT_PROXY_DOMAIN_LABEL stringByAppendingString:envSuffix];
+    NSString *spikyProxyDomainKey = [CT_SPIKY_PROXY_DOMAIN_LABEL stringByAppendingString:envSuffix];
+
+    NSString *_accountId = [self metaDataForAttribute:accountIdKey];
+    NSString *_accountToken = [self metaDataForAttribute:tokenKey];
+    NSString *_accountRegion = [self metaDataForAttribute:regionKey];
+    NSString *_proxyDomain = [self metaDataForAttribute:proxyDomainKey];
+    NSString *_spikyProxyDomain = [self metaDataForAttribute:spikyProxyDomainKey];
+
     if (_accountRegion) {
         [CleverTap setCredentialsWithAccountID:_accountId token:_accountToken region:_accountRegion];
     } else {

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.h
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.h
@@ -27,6 +27,10 @@ typedef void (*UserEventLogCallback) (const char *, const char *);
 + (void)registerPush;
 + (void)setApplicationIconBadgeNumber:(int)num;
 
+#pragma mark - Unity Helpers
+
++ (NSString * _Nullable)getUnityPlayerPrefsString:(NSString *)key;
+
 #pragma mark - Offline API
 
 - (void)setOffline:(BOOL)enabled;

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -158,11 +158,10 @@ static BOOL shouldDisableBuffers = YES;
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     NSString *value = [defaults stringForKey:key];
     
-    NSLog(@"CleverTap: Looking for key '%@' in NSUserDefaults. Found: %@", 
-          key, value ? [NSString stringWithFormat:@"'%@'", value] : @"(null)");
-    
     // Optional: Log all PlayerPrefs keys for debugging
     #if DEBUG
+    NSLog(@"CleverTap: Looking for key '%@' in NSUserDefaults. Found: %@", key, value ? [NSString stringWithFormat:@"'%@'", value] : @"(null)");
+
     NSDictionary *allDefaults = [defaults dictionaryRepresentation];
     NSSet *playerPrefsKeys = [allDefaults keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL *stop) {
         // Filter for likely Unity keys if needed

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -147,6 +147,33 @@ static BOOL shouldDisableBuffers = YES;
     [CleverTap setLocation:location];
 }
 
+#pragma mark - Unity Helpers
+
++ (NSString *)getUnityPlayerPrefsString:(NSString *)key {
+    if (!key) {
+        NSLog(@"CleverTap: getUnityPlayerPrefsString called with nil key");
+        return nil;
+    }
+    
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *value = [defaults stringForKey:key];
+    
+    NSLog(@"CleverTap: Looking for key '%@' in NSUserDefaults. Found: %@", 
+          key, value ? [NSString stringWithFormat:@"'%@'", value] : @"(null)");
+    
+    // Optional: Log all PlayerPrefs keys for debugging
+    #if DEBUG
+    NSDictionary *allDefaults = [defaults dictionaryRepresentation];
+    NSSet *playerPrefsKeys = [allDefaults keysOfEntriesPassingTest:^BOOL(id key, id obj, BOOL *stop) {
+        // Filter for likely Unity keys if needed
+        return YES;
+    }];
+    NSLog(@"CleverTap: All NSUserDefaults keys: %@", [playerPrefsKeys allObjects]);
+    #endif
+    
+    return value;
+}
+
 #pragma mark - Offline API
 
 - (void)setOffline:(BOOL)enabled{

--- a/CleverTap/Runtime/CleverTap.cs
+++ b/CleverTap/Runtime/CleverTap.cs
@@ -3,6 +3,7 @@ using CleverTapSDK.Constants;
 using CleverTapSDK.Utilities;
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace CleverTapSDK {
     public static class CleverTap {
@@ -609,6 +610,24 @@ namespace CleverTapSDK {
         public static void SyncCustomTemplates(bool isProduction) =>
             cleverTapCustomInApps.SyncCustomTemplates(isProduction);
 
+        #endregion
+
+        #region Methods - Multi-Environment Support
+        /// <summary>
+        /// Stores the selected CleverTap environment key in PlayerPrefs for debug builds,
+        /// allowing the app to persist and reuse the environment configuration during development.
+        /// </summary>
+        /// <param name="environmentKey">
+        /// The CleverTap environment key to be selected and stored for the current debug session.
+        /// </param>
+        public static void SelectCleverTapEnvironmentCredential(CleverTapEnvironmentKey environmentKey)
+        {
+            if (Debug.isDebugBuild)
+            {
+                PlayerPrefs.SetString("CleverTapEnvironment", $"{environmentKey}");
+                PlayerPrefs.Save();
+            }
+        }
         #endregion
     }
 }

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Plugins/x64/sqlite3.dll.meta
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Plugins/x64/sqlite3.dll.meta
@@ -22,8 +22,8 @@ PluginImporter:
       settings:
         Exclude Android: 1
         Exclude Editor: 0
-        Exclude Linux64: 0
-        Exclude OSXUniversal: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
         Exclude WebGL: 1
         Exclude Win: 0
         Exclude Win64: 0
@@ -35,15 +35,15 @@ PluginImporter:
         DefaultValueInitialized: true
         OS: AnyOS
     Linux64:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: x86_64
     OSXUniversal:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: x86_64
     Win:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: x86
     Win64:

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Plugins/x64/sqlite3.dll.meta
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Plugins/x64/sqlite3.dll.meta
@@ -1,2 +1,62 @@
 fileFormatVersion: 2
 guid: cfc37f0af4a3f48c2bfe2071f9737121
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 3
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+    Android:
+      enabled: 0
+      settings:
+        AndroidLibraryDependee: UnityLibrary
+        AndroidSharedLibraryType: Executable
+        CPU: ARMv7
+    Any:
+      enabled: 0
+      settings:
+        Exclude Android: 1
+        Exclude Editor: 0
+        Exclude Linux64: 0
+        Exclude OSXUniversal: 0
+        Exclude WebGL: 1
+        Exclude Win: 0
+        Exclude Win64: 0
+        Exclude iOS: 1
+    Editor:
+      enabled: 1
+      settings:
+        CPU: x86_64
+        DefaultValueInitialized: true
+        OS: AnyOS
+    Linux64:
+      enabled: 1
+      settings:
+        CPU: x86_64
+    OSXUniversal:
+      enabled: 1
+      settings:
+        CPU: x86_64
+    Win:
+      enabled: 1
+      settings:
+        CPU: x86
+    Win64:
+      enabled: 1
+      settings:
+        CPU: x86_64
+    iOS:
+      enabled: 0
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: AnyCPU
+        CompileFlags: 
+        FrameworkDependencies: 
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Plugins/x86/sqlite3.dll.meta
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Plugins/x86/sqlite3.dll.meta
@@ -12,24 +12,24 @@ PluginImporter:
   validateReferences: 1
   platformData:
     Android:
-      enabled: 1
+      enabled: 0
       settings:
         AndroidLibraryDependee: UnityLibrary
         AndroidSharedLibraryType: Executable
         CPU: ARMv7
     Any:
-      enabled: 1
+      enabled: 0
       settings:
-        Exclude Android: 0
-        Exclude Editor: 1
+        Exclude Android: 1
+        Exclude Editor: 0
         Exclude Linux64: 0
         Exclude OSXUniversal: 0
-        Exclude WebGL: 0
+        Exclude WebGL: 1
         Exclude Win: 0
         Exclude Win64: 0
-        Exclude iOS: 0
+        Exclude iOS: 1
     Editor:
-      enabled: 0
+      enabled: 1
       settings:
         CPU: AnyCPU
         DefaultValueInitialized: true
@@ -43,7 +43,7 @@ PluginImporter:
       settings:
         CPU: x86
     WebGL:
-      enabled: 1
+      enabled: 0
       settings: {}
     Win:
       enabled: 1
@@ -54,7 +54,7 @@ PluginImporter:
       settings:
         CPU: None
     iOS:
-      enabled: 1
+      enabled: 0
       settings:
         AddToEmbeddedBinaries: false
         CPU: AnyCPU

--- a/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Plugins/x86/sqlite3.dll.meta
+++ b/CleverTap/Runtime/Native/UnityNativeWrapper/Sqlite/Plugins/x86/sqlite3.dll.meta
@@ -22,8 +22,8 @@ PluginImporter:
       settings:
         Exclude Android: 1
         Exclude Editor: 0
-        Exclude Linux64: 0
-        Exclude OSXUniversal: 0
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
         Exclude WebGL: 1
         Exclude Win: 0
         Exclude Win64: 0
@@ -35,11 +35,11 @@ PluginImporter:
         DefaultValueInitialized: true
         OS: AnyOS
     Linux64:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: None
     OSXUniversal:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: x86
     WebGL:

--- a/CleverTap/Runtime/Utilities/CleverTapEnvironment.cs
+++ b/CleverTap/Runtime/Utilities/CleverTapEnvironment.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace CleverTapSDK.Utilities
+{
+    public enum CleverTapEnvironmentKey
+    {
+        TEST = 0,
+        DEV = 1,
+        STAGE = 2,
+        PROD = 3
+    }
+
+    [Serializable]
+    public struct CleverTapEnvironmentCredential
+    {
+        #region Project Settings
+        /// <summary>
+        /// CleverTap project Account Id (Project ID).
+        /// </summary>
+        public string CleverTapAccountId;
+
+        /// <summary>
+        /// CleverTap project Account token (Project Token).
+        /// </summary>
+        public string CleverTapAccountToken;
+
+        /// <summary>
+        /// CleverTap Region Code.
+        /// </summary>
+        public string CleverTapAccountRegion;
+
+        /// <summary>
+        /// Custom Proxy Domain.
+        /// </summary>
+        public string CleverTapProxyDomain;
+
+        /// <summary>
+        /// Spiky Proxy Domain.
+        /// </summary>
+        public string CleverTapSpikyProxyDomain;
+        #endregion
+    }
+}

--- a/CleverTap/Runtime/Utilities/CleverTapEnvironment.cs.meta
+++ b/CleverTap/Runtime/Utilities/CleverTapEnvironment.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3749a52a19de94632909d5b6fc8ea2c0

--- a/CleverTap/Runtime/Utilities/SerializableDictionary.cs
+++ b/CleverTap/Runtime/Utilities/SerializableDictionary.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CleverTapSDK.Utilities
+{
+    [Serializable]
+    public class SerializableDictionary<TKey, TValue>
+    {
+        /// <summary>
+        /// Serializable representation of a key-value pair.
+        /// </summary>
+        [Serializable]
+        public class KeyValuePair
+        {
+            /// <summary>
+            /// The key of the pair.
+            /// </summary>
+            public TKey Key;
+
+            /// <summary>
+            /// The value of the pair.
+            /// </summary>
+            public TValue Value;
+        }
+
+        /// <summary>
+        /// List of key-value pairs representing the dictionary.
+        /// </summary>
+        public List<KeyValuePair> Items = new List<KeyValuePair>();
+
+        /// <summary>
+        /// Creates a SerializableDictionary from a standard Dictionary.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to convert.</param>
+        /// <returns>A SerializableDictionary containing the same data.</returns>
+        public static SerializableDictionary<TKey, TValue> FromDictionary(Dictionary<TKey, TValue> dictionary)
+        {
+            var serializable = new SerializableDictionary<TKey, TValue>();
+            foreach (var kvp in dictionary)
+            {
+                serializable.Items.Add(new KeyValuePair { Key = kvp.Key, Value = kvp.Value });
+            }
+            return serializable;
+        }
+
+        /// <summary>
+        /// Converts the SerializableDictionary to a standard Dictionary.
+        /// </summary>
+        /// <returns>A Dictionary containing the same data.</returns>
+        public Dictionary<TKey, TValue> ToDictionary()
+        {
+            return Items.ToDictionary(item => item.Key, item => item.Value);
+        }
+    }
+}

--- a/CleverTap/Runtime/Utilities/SerializableDictionary.cs.meta
+++ b/CleverTap/Runtime/Utilities/SerializableDictionary.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 02a9ab91043c24656acb3f6e2fb6deb6


### PR DESCRIPTION
Refactor CleverTap settings to support multiple environments (TEST, DEV, STAGE, PROD) using a serializable dictionary of credentials. Update Android and iOS post-build processors, runtime access, and editor UI to handle environment selection and storage. Add PlayerPrefs-based environment switching for debug builds, and update native iOS code to read environment-specific credentials. Introduce SerializableDictionary and CleverTapEnvironmentCredential utility classes.

Introduces environment-specific CleverTap initialization by reading environment settings from Unity PlayerPrefs or AndroidManifest metadata for debug builds, and always using the primary environment for release builds. Adds a utility to read PlayerPrefs from various Unity formats. Updates CleverTapUnityApplication to initialize CleverTap before registering lifecycle callbacks to ensure correct configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-environment configuration for CleverTap credentials (PROD, STAGE, DEV, TEST)
  * Runtime environment selection in debug builds and environment-aware initialization for iOS/Android
  * Development-build mode publishes per-environment metadata for easier testing

* **Chores**
  * Settings UI moved to serialized asset editing; settings refactored to environment dictionary and serializable types
  * Improved validation and error logging for environment configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->