### PR TITLE
Fix/unity 2022 gradle and json quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Change Log
 ==========
 
+Unreleased
+-------------------------------------------
+- **Fix:** Android builds on Unity 2022/2023 - `AndroidProjectPostProcessor` no longer rewrites the generated Gradle files onto a Unity 2021-era toolchain. Forcing `JavaVersion.VERSION_17` failed to compile against the OpenJDK 11 those editors bundle, stripping the `setupSymbols.gradle` / `keepUnitySymbols.gradle` apply lines broke symbol packaging, and forcing `minSdk 26` silently discarded the project's Player Settings value. Those three rewrites are now guarded behind `#if !UNITY_2022_1_OR_NEWER`; the `compileSdk`/`targetSdk` 36 bump still applies on every pre-Unity 6 editor.
+- **Fix:** `GetVariableValue` returned malformed JSON on Android for string variables containing a double quote, a backslash or a control character - the Java wrapper built the JSON string by concatenation instead of escaping. `CleverTapUnityPlugin.getVariableValue` now uses `JSONObject.quote`.
+
 Version 5.5.5 *(Aug 2026)*
 -------------------------------------------
 - Updated to [CleverTap Android SDK v8.4.1](https://github.com/CleverTap/clevertap-android-sdk/releases/tag/corev8.4.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Unreleased
 - **Fix:** String variables whose value is itself JSON were lost on both platforms. `AndroidVar` now falls back to the raw representation when the wrapper returns such a value unquoted, `IOSVar` keeps the last known good value when the native value is not a string, and both guard `Util.FillInValues` on the target actually being an `IDictionary` instead of overwriting a non-dictionary variable.
 - **Fix:** `AndroidVar` returned `defaultValue` only after attempting to deserialize; it now null-checks the JNI result up front, matching `IOSVar`.
 - **Fix:** String variable *defaults* were corrupted on iOS - `defineVar` stripped the outer quotes off the serialized JSON fragment instead of decoding it, leaving every inner quote escaped. It now JSON-decodes the fragment and falls back to the old behaviour only if that fails.
+- **Fix:** `CleverTapSettings` configuration errors raised by `AndroidProjectPostProcessor` and `IOSPostBuildProcessor` were logged with the example app's `[CTExample]` prefix instead of `[CleverTap]`.
 
 Version 5.5.5 *(Aug 2026)*
 -------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Unreleased
 -------------------------------------------
 - **Fix:** Android builds on Unity 2022/2023 - `AndroidProjectPostProcessor` no longer rewrites the generated Gradle files onto a Unity 2021-era toolchain. Forcing `JavaVersion.VERSION_17` failed to compile against the OpenJDK 11 those editors bundle, stripping the `setupSymbols.gradle` / `keepUnitySymbols.gradle` apply lines broke symbol packaging, and forcing `minSdk 26` silently discarded the project's Player Settings value. Those three rewrites are now guarded behind `#if !UNITY_2022_1_OR_NEWER`; the `compileSdk`/`targetSdk` 36 bump still applies on every pre-Unity 6 editor.
 - **Fix:** `GetVariableValue` returned malformed JSON on Android for string variables containing a double quote, a backslash or a control character - the Java wrapper built the JSON string by concatenation instead of escaping. `CleverTapUnityPlugin.getVariableValue` now uses `JSONObject.quote`.
+- **Fix:** String variables whose value is itself JSON were lost on both platforms. `AndroidVar` now falls back to the raw representation when the wrapper returns such a value unquoted, `IOSVar` keeps the last known good value when the native value is not a string, and both guard `Util.FillInValues` on the target actually being an `IDictionary` instead of overwriting a non-dictionary variable.
+- **Fix:** `AndroidVar` returned `defaultValue` only after attempting to deserialize; it now null-checks the JNI result up front, matching `IOSVar`.
+- **Fix:** String variable *defaults* were corrupted on iOS - `defineVar` stripped the outer quotes off the serialized JSON fragment instead of decoding it, leaving every inner quote escaped. It now JSON-decodes the fragment and falls back to the old behaviour only if that fails.
 
 Version 5.5.5 *(Aug 2026)*
 -------------------------------------------

--- a/CleverTap/Editor/AndroidProjectPostProcessor.cs
+++ b/CleverTap/Editor/AndroidProjectPostProcessor.cs
@@ -112,6 +112,13 @@ namespace CleverTapSDK.Private
         {
             string content = File.ReadAllText(gradlePath);
 
+            // Unity 2021 and older need the generated project pushed onto a toolchain AGP 8.x
+            // accepts. Unity 2022/2023 must not get these rewrites: those editors bundle
+            // OpenJDK 11 so JavaVersion.VERSION_17 fails to compile, they do generate
+            // setupSymbols.gradle / keepUnitySymbols.gradle so dropping the apply lines breaks
+            // symbol packaging, and they already honour minSdk from Player Settings so
+            // overriding it silently discards the project's choice.
+#if !UNITY_2022_1_OR_NEWER
             // Remove Unity symbol script apply lines that may not exist in all environments
             content = Regex.Replace(content, @"apply from: 'setupSymbols\.gradle'\r?\n?", "");
             content = Regex.Replace(content, @"apply from: '\.\./shared/keepUnitySymbols\.gradle'\r?\n?", "");
@@ -119,13 +126,15 @@ namespace CleverTapSDK.Private
             // Java 17 required for AGP 8.x / latest Gradle
             content = content.Replace("JavaVersion.VERSION_11", "JavaVersion.VERSION_17");
 
+            content = Regex.Replace(content, @"\bminSdkVersion\s+\d+", "minSdkVersion 26");
+            content = Regex.Replace(content, @"\bminSdk\b\s+\d+", "minSdk 26");
+#endif
+
             // Enforce SDK versions regardless of what Unity set.
             // Match both old-style (compileSdkVersion 33) and new-style (compileSdk 33).
             // The \b word boundary ensures 'compileSdk' doesn't match inside 'compileSdkVersion'.
             content = Regex.Replace(content, @"\bcompileSdkVersion\s+\d+", "compileSdkVersion 36");
             content = Regex.Replace(content, @"\bcompileSdk\b\s+\d+", "compileSdk 36");
-            content = Regex.Replace(content, @"\bminSdkVersion\s+\d+", "minSdkVersion 26");
-            content = Regex.Replace(content, @"\bminSdk\b\s+\d+", "minSdk 26");
             content = Regex.Replace(content, @"\btargetSdkVersion\s+\d+", "targetSdkVersion 36");
             content = Regex.Replace(content, @"\btargetSdk\b\s+\d+", "targetSdk 36");
 

--- a/CleverTap/Editor/AndroidProjectPostProcessor.cs
+++ b/CleverTap/Editor/AndroidProjectPostProcessor.cs
@@ -228,7 +228,7 @@ namespace CleverTapSDK.Private
 
             if (settings.Environments == null || settings.Environments.Items == null)
             {
-                Debug.LogError("[CTExample] CleverTapSettings - Environments are not configured.");
+                Debug.LogError("[CleverTap] CleverTapSettings - Environments are not configured.");
                 return;
             }
 
@@ -236,13 +236,13 @@ namespace CleverTapSDK.Private
 
             if (environmentCredentials.Count == 0)
             {
-                Debug.LogError("[CTExample] CleverTapSettings - Environments are not configured.");
+                Debug.LogError("[CleverTap] CleverTapSettings - Environments are not configured.");
                 return;
             }
 
             if (!environmentCredentials.TryGetValue(settings.DefaultEnvironment, out CleverTapEnvironmentCredential environmentCredential))
             {
-                Debug.LogError($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvironment}");
+                Debug.LogError($"[CleverTap] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvironment}");
                 return;
             }
 

--- a/CleverTap/Editor/IOSPostBuildProcessor.cs
+++ b/CleverTap/Editor/IOSPostBuildProcessor.cs
@@ -122,7 +122,7 @@ namespace CleverTapSDK.Private
 
             if (settings.Environments == null || settings.Environments.Items == null)
             {
-                Debug.LogError("[CTExample] CleverTapSettings - Environments are not configured.");
+                Debug.LogError("[CleverTap] CleverTapSettings - Environments are not configured.");
                 return;
             }
 
@@ -130,13 +130,13 @@ namespace CleverTapSDK.Private
 
             if (environments == null || environments.Count == 0)
             {
-                Debug.LogError("[CTExample] CleverTapSettings - Environments are not configured.");
+                Debug.LogError("[CleverTap] CleverTapSettings - Environments are not configured.");
                 return;
             }
 
             if (!environments.TryGetValue(settings.DefaultEnvironment, out CleverTapEnvironmentCredential environmentValue))
             {
-                Debug.LogError($"[CTExample] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvironment}");
+                Debug.LogError($"[CleverTap] CleverTapSettings - Environment is null or not configured for {settings.DefaultEnvironment}");
                 return;
             }
 

--- a/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
+++ b/CleverTap/Plugins/Android/clevertap-android-wrapper.androidlib/src/main/java/com/clevertap/unity/CleverTapUnityPlugin.java
@@ -756,7 +756,9 @@ public class CleverTapUnityPlugin {
             if (parsedJson != null)
                 return parsedJson;
 
-            return "\"" + stringValue + "\"";
+            // JSONObject.quote escapes quotes, backslashes and control characters;
+            // string concatenation does not and yields invalid JSON for such values.
+            return JSONObject.quote(stringValue);
         } else {
             return value.toString();
         }

--- a/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
+++ b/CleverTap/Plugins/iOS/CleverTapUnityManager.mm
@@ -963,7 +963,16 @@ static BOOL shouldDisableBuffers = YES;
     }
     else if ([kind isEqualToString:@"string"])
     {
-        NSString *value = [defaultValue substringWithRange:NSMakeRange(1, [defaultValue length] - 2)];
+        // The C# layer passes the default as a serialized JSON fragment, so it has to be JSON
+        // decoded. Only stripping the surrounding quotes leaves every inner quote escaped, which
+        // corrupts string defaults that are themselves JSON or that contain quotes/backslashes.
+        id decoded = [NSJSONSerialization JSONObjectWithData:data
+                                                    options:NSJSONReadingAllowFragments
+                                                      error:&error];
+        NSString *value = [decoded isKindOfClass:[NSString class]]
+            ? decoded
+            : [defaultValue substringWithRange:NSMakeRange(1, [defaultValue length] - 2)];
+        error = nil;
         var = [self.cleverTap defineVar:name withString:value];
     }
     else

--- a/CleverTap/Runtime/Android/AndroidVar.cs
+++ b/CleverTap/Runtime/Android/AndroidVar.cs
@@ -11,18 +11,30 @@ namespace CleverTapSDK.Android {
         public override T Value {
             get {
                 string jsonRepresentation = CleverTapAndroidJNI.CleverTapJNIInstance.Call<string>("getVariableValue", name);
+                if (jsonRepresentation == null) {
+                    return defaultValue;
+                }
+
                 if (jsonRepresentation == Json.Serialize(value)) {
                     return value;
                 }
 
                 object newValue = Json.Deserialize(jsonRepresentation);
-                if (newValue is IDictionary) {
-                    Util.FillInValues(newValue, value);
+
+                if (typeof(T) == typeof(string)) {
+                    // The Android wrapper returns a string variable unquoted when its content
+                    // itself parses as JSON, so it deserializes to a dictionary or a list rather
+                    // than to a string. Keep the raw representation in that case - it is the
+                    // string that was defined.
+                    value = (T)(object)(newValue as string ?? jsonRepresentation);
                 } else if (newValue == null) {
                     value = defaultValue;
+                } else if (newValue is IDictionary && value is IDictionary) {
+                    Util.FillInValues(newValue, value);
                 } else {
                     value = (T)Convert.ChangeType(newValue, typeof(T));
                 }
+
                 return value;
             }
         }

--- a/CleverTap/Runtime/IOS/IOSVar.cs
+++ b/CleverTap/Runtime/IOS/IOSVar.cs
@@ -36,7 +36,17 @@ namespace CleverTapSDK.IOS {
 
                 object newValue = Json.Deserialize(jsonRepresentation);
 
-                if (newValue is IDictionary) {
+                if (typeof(T) == typeof(string)) {
+                    // getVariableValue always returns a JSON fragment, so a string variable comes
+                    // back quoted and escaped and deserializes to the raw string. Anything else
+                    // means the native value was not a string - keep the last known good value
+                    // instead of exposing the escaped representation.
+                    if (newValue is string stringValue) {
+                        value = (T)(object)stringValue;
+                    }
+                } else if (newValue == null) {
+                    value = defaultValue;
+                } else if (newValue is IDictionary && value is IDictionary) {
                     Util.FillInValues(newValue, value);
                 } else {
                     value = (T)Convert.ChangeType(newValue, typeof(T));


### PR DESCRIPTION
## Summary

Five independent fixes found while shipping a Unity 2022.3 title on the CleverTap Unity SDK. They are grouped here because they were hit together, but each stands alone and the commits are separate:

1. Android builds are broken on Unity 2022 / 2023 (`AndroidProjectPostProcessor`)
2. `GetVariableValue` returns malformed JSON on Android (`CleverTapUnityPlugin.java`)
3. String variables are mishandled on both platforms (`AndroidVar`, `IOSVar`)
4. String variable defaults are corrupted on iOS (`CleverTapUnityManager.mm`)
5. `[CTExample]` log prefix inside the SDK (both build post-processors)

Items 2-4 are the same underlying defect - the Unity <-> native boundary passes variable values as JSON fragments, and three places along that boundary build or consume those fragments without escaping.

### 1. Android builds are broken on Unity 2022 / 2023

`AndroidProjectPostProcessor.PatchLegacyGradleFile` runs for every editor older than Unity 6 (the `#else` of `UNITY_6000_0_OR_NEWER`) and rewrites the generated Gradle files onto a Unity 2021-era toolchain. On Unity 2022/2023 all three of those rewrites are wrong:

| Rewrite | Effect on Unity 2022 / 2023 |
| --- | --- |
| `JavaVersion.VERSION_11` -> `VERSION_17` | These editors bundle OpenJDK 11. The Gradle compile fails outright. |
| Strips `apply from: 'setupSymbols.gradle'` and `apply from: '../shared/keepUnitySymbols.gradle'` | Both files *are* generated by these editors. Removing the apply lines breaks Unity's symbol packaging. |
| Forces `minSdk` / `minSdkVersion` to 26 | `minSdk` is already honoured from Player Settings, so this silently discards the project's configured value (24 in our case). |

Those three are now guarded behind `#if !UNITY_2022_1_OR_NEWER`, so Unity 2021 and older keep the existing behaviour unchanged.

The `compileSdk` / `targetSdk` 36 bump is **not** guarded and still applies on every pre-Unity 6 editor - that part is required by the Android SDK 8.x dependency and works fine on 2022.3.

We have been carrying this as an out-of-package `IPostGenerateGradleAndroidProject` that snapshots the Gradle files before CleverTap's callback (order 99) and putsUnity's values back afterwards. Fixing it at the source removes the need for that workaround.

### 2. `GetVariableValue` returns malformed JSON on Android

`CleverTapUnityPlugin.getVariableValue` built the JSON representation of a plain string variable by concatenation:

```java
return "\"" + stringValue + "\"";
```

Any value containing a double quote, a backslash or a control character produces invalid JSON, which then fails to deserialize on the Unity side. `JSONObject.quote` (already imported in this file) escapes all three correctly.

Example: a string variable set to `He said "hi"` previously returned `"He said "hi""`; it now returns `"He said \"hi\""`.

### 3. String variables are mishandled on both platforms

With the wrapper now emitting a valid JSON fragment, the C# and Objective-C sides around it still get string variables wrong.

**`AndroidVar.Value`**

- No null check on the JNI result. `Json.Serialize` / `Json.Deserialize` were being called on `null`. `IOSVar` already guards this.
- `getVariableValue` returns a string variable **unquoted** when its content itself parses as JSON (the `tryParseJson` short-circuit above). It therefore deserializes to a dictionary or list, so a `Var<string>` fell into `Util.FillInValues` and the caller kept seeing the stale value. It now falls back to the raw representation, which is the string that was defined.
- `Util.FillInValues` is now guarded on the target being an `IDictionary` too, so a non-dictionary variable is no longer passed to it.

**`IOSVar.Value`**

- For a `Var<string>`, only assign when the fragment deserialized to a string. Anything else means the native value was not a string, so keep the last known good value rather than exposing the escaped representation.
- Restored the `null` and `IDictionary` guards to match `AndroidVar`. `Convert.ChangeType(null, typeof(int))` throws `InvalidCastException`.

### 4. String variable *defaults* are corrupted on iOS

`CleverTapUnityManager defineVar:kind:andDefaultValue:` handled the `string` kind by chopping off the first and last character:

```objc
NSString *value = [defaultValue substringWithRange:NSMakeRange(1, [defaultValue length] - 2)];
```

The C# layer passes the default as a *serialized JSON fragment*, so this leaves every inner quote escaped. Any string default that is itself JSON, or that containsa quote or a backslash, was registered corrupted. It now JSON-decodes the fragment (`NSJSONReadingAllowFragments`) and falls back to the old behaviour only if decoding fails.

### 5. `[CTExample]` log prefix inside the SDK

Six `Debug.LogError` calls in `AndroidProjectPostProcessor` and `IOSPostBuildProcessor` are tagged `[CTExample]`, copy-pasted from the example app. Both files already use `[CleverTap]` everywhere else, and `[CTExample]` belongs to `CTExample/Assets/Scripts/Logger.cs` - so an integrator hitting a misconfigured `CleverTapSettings` was pointed at the wrong project. Retagged to `[CleverTap]`.

## Testing

- Android build on Unity 2022.3.62f3, `minSdk` 24 / `targetSdk` 36: the generated `unityLibrary/build.gradle` and `launcher/build.gradle` keep `JavaVersion.VERSION_11`, keep both `apply from:` symbol lines, keep `minSdkVersion 24`, and take `compileSdk`/`targetSdk` 36. Build and symbol packaging succeed.
- `GetVariableValue` on Android for string variables containing quotes and backslashes now round-trips through the Unity deserializer.
- String variables whose value is itself a JSON document (`{"a":1}`) now read back as that string on both Android and iOS instead of returning the stale/default value.
- String defaults containing quotes are registered on iOS with the quotes intact.
- Unity 2021 and Unity 6 code paths are untouched: the Unity 6 branch is unchanged, and the pre-2022 branch compiles to exactly the previous sequence of rewrites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android and iOS variable handling, including string values, JSON escaping, null responses, and default values.
  * Preserved valid variable values across platforms when responses contain JSON-like content.
  * Improved Android build processing compatibility for Unity 2022 and newer.
  * Corrected configuration error log labels for clearer diagnostics.
* **Documentation**
  * Added an Unreleased changelog entry summarizing these fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->